### PR TITLE
fix for SyntaxError

### DIFF
--- a/lib/tugboat/cli.rb
+++ b/lib/tugboat/cli.rb
@@ -172,7 +172,7 @@ module Tugboat
                   :type => :string,
                   :aliases => "-s",
                   :desc => "The name of the snapshot"
-    def snapshot(name=nil, snapshot_name)
+    def snapshot(name=nil, snapshot_name=nil)
       Middleware.sequence_snapshot_droplet.call({
         "user_droplet_id" => options[:id],
         "user_droplet_name" => options[:name],


### PR DESCRIPTION
**_NOTE I AM NOT A RUBY DEVELOPER - I'm a PHP developer - this fix worked for me**_

This Pull Request fixes issue #10 for me

The error was:

/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib/ruby/1.8/rubygems/custom_require.rb:31:in `gem_original_require': /Library/Ruby/Gems/1.8/gems/tugboat-0.0.3/lib/tugboat/cli.rb:175: syntax error, unexpected ')', expecting '=' (SyntaxError)

My solution was to add "=nil" to one line of code

Now I can continue 

Full command line:

phils-imac-2012:~ phil$ tugboat authorize
/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib/ruby/1.8/rubygems/custom_require.rb:31:in `gem_original_require': /Library/Ruby/Gems/1.8/gems/tugboat-0.0.3/lib/tugboat/cli.rb:175: syntax error, unexpected ')', expecting '=' (SyntaxError)
/Library/Ruby/Gems/1.8/gems/tugboat-0.0.3/lib/tugboat/cli.rb:184: syntax error, unexpected kEND, expecting $end
    from /System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib/ruby/1.8/rubygems/custom_require.rb:31:in`require'
    from /Library/Ruby/Gems/1.8/gems/tugboat-0.0.3/lib/tugboat.rb:1
    from /System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib/ruby/1.8/rubygems/custom_require.rb:31:in `gem_original_require'
    from /System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib/ruby/1.8/rubygems/custom_require.rb:31:in`require'
    from /Library/Ruby/Gems/1.8/gems/tugboat-0.0.3/bin/tugboat:2
    from /usr/bin/tugboat:19:in `load'
    from /usr/bin/tugboat:19

phils-imac-2012:~ phil$ nano  /Library/Ruby/Gems/1.8/gems/tugboat-0.0.3/lib/tugboat/cli.rb

phils-imac-2012:~ phil$ tugboat authorize
Faraday: you may want to install system_timer for reliable timeouts
Note: You can get this information from digitalocean.com/api_access

Enter your client key: 
