### PR TITLE
Support MRI 1.8.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
 rvm:
+  - 1.8.7
   - 1.9.3
   - 2.0.0

--- a/tugboat.gemspec
+++ b/tugboat.gemspec
@@ -26,5 +26,4 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rspec-expectations", "~> 2.13.0"
   gem.add_development_dependency "rspec-mocks", "~> 2.13.0"
   gem.add_development_dependency "webmock", "~> 1.11.0"
-  gem.add_development_dependency "debugger", "~> 1.5.0"
 end


### PR DESCRIPTION
- Add 1.8.7 to `.travis.yml`.
- Remove `debugger` from the gemspec.

Closes #20.
