### PR TITLE
Stub out Kernel.exec for testing the options sent to SSH.

### DIFF
--- a/spec/middleware/ssh_droplet_spec.rb
+++ b/spec/middleware/ssh_droplet_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe Tugboat::Middleware::SSHDroplet do
+  include_context "spec"
+
+  let(:app) { lambda { |env| } }
+  let(:env) { {} }
+
+  before do
+    Kernel.stub!(:exec)
+  end
+
+  describe ".call" do
+
+    it "exec ssh with correct options" do
+      Kernel.should_receive(:exec).with("ssh",
+                        "-o", "IdentitiesOnly=yes",
+                        "-o", "LogLevel=ERROR",
+                        "-o", "StrictHostKeyChecking=no",
+                        "-o", "UserKnownHostsFile=/dev/null",
+                        "-i", ssh_key_path,
+                        "-p", ssh_port,
+                        "#{ssh_user}@#{droplet_ip}")
+
+      env["droplet_ip"] = droplet_ip
+      env["config"] = config
+
+      described_class.new(app).call(env)
+    end
+
+  end
+
+end

--- a/spec/shared/environment.rb
+++ b/spec/shared/environment.rb
@@ -9,6 +9,7 @@ shared_context "spec" do
   let(:ssh_port)         { "22" }
   let(:ssh_key_path)     { "~/.ssh/id_rsa2" }
   let(:droplet_name)     { "foo" }
+  let(:droplet_ip)       { "33.33.33.10" }
   let(:droplet_id)       { 1234 }
   let(:ocean)            { DigitalOcean::API.new :client_id => client_key, :api_key =>api_key }
 
@@ -18,7 +19,7 @@ shared_context "spec" do
 
 
     # Set a temprary project path and create fake config.
-    config.create_config_file(client_key, api_key, ssh_user, ssh_key_path, ssh_port)
+    config.create_config_file(client_key, api_key, ssh_key_path, ssh_user, ssh_port)
     config.reload!
 
     # Keep track of the old stderr / out


### PR DESCRIPTION
Also fixed an issue with the test environment having mis-ordered
arguments sent to create_config_file.

Due to a conversation in #24.

Wondering if more can be done here.
