### PR TITLE
Run specs in a random order

### DIFF
--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Tugboat::Configuration do
+  include_context "spec"
+
   let(:tmp_path)             { project_path + "/tmp/tugboat" }
 
   after :each do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,8 @@ Coveralls.wear!
 RSpec.configure do |config|
   # Pretty tests
   config.color_enabled = true
+
+  config.order = :random
 end
 
 def project_path


### PR DESCRIPTION
This is to avoid order dependency bugs.

The "has a data attribute" example in `spec/config_spec.rb` failed with
seed 1549. Added `include_context "spec"` to resolve this.
