### PR TITLE
Adjust the Coveralls configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .bundle
 .rvmrc
 Gemfile.lock
+coverage
 doc/*
 log/*
 pkg/*

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,10 @@
+require 'coveralls'
+Coveralls.wear! { add_filter '/spec/' }
+
 require 'tugboat'
 require 'webmock/rspec'
 require 'digital_ocean'
 require "shared/environment"
-
-require 'coveralls'
-Coveralls.wear!
 
 RSpec.configure do |config|
   # Pretty tests


### PR DESCRIPTION
- Add the coverage directory to `.gitignore`.
- Move setup to the top of the spec helper.
- Filter out files with /spec/ in the path.
