### PR TITLE
Update the defaults for droplet creation

### DIFF
--- a/lib/tugboat/cli.rb
+++ b/lib/tugboat/cli.rb
@@ -87,12 +87,12 @@ module Tugboat
     method_option  "size",
                    :type => :numeric,
                    :aliases => "-s",
-                   :default => 64,
+                   :default => 66,
                    :desc => "The size_id of the droplet"
     method_option  "image",
                    :type => :numeric,
                    :aliases => "-i",
-                   :default => 2676,
+                   :default => 284203,
                    :desc => "The image_id of the droplet"
     method_option  "region",
                    :type => :numeric,


### PR DESCRIPTION
DigitalOcean seems to have changed the ID's of their server
images...this update continues to use:

`Ubuntu 12.04 x64 Server (id: 284203, distro: Ubuntu)`

As the default image.

I also lowered the default droplet size to 512mb.
