### PR TITLE
Add a resize command

### DIFF
--- a/lib/tugboat/cli.rb
+++ b/lib/tugboat/cli.rb
@@ -250,6 +250,29 @@ module Tugboat
         "user_droplet_fuzzy_name" => name
       })
     end
+
+    desc "resize FUZZY_NAME", "Resize a droplet"
+    method_option "id",
+                  :type => :numeric,
+                  :aliases => "-i",
+                  :desc => "The ID of the droplet."
+    method_option "name",
+                  :type => :string,
+                  :aliases => "-n",
+                  :desc => "The exact name of the droplet"
+    method_option "size",
+                  :type => :numeric,
+                  :aliases => "-s",
+                  :required => true,
+                  :desc => "The size_id to resize the droplet to"
+    def resize(name=nil)
+      Middleware.sequence_resize_droplet.call({
+        "user_droplet_id" => options[:id],
+        "user_droplet_name" => options[:name],
+        "user_droplet_size" => options[:size],
+        "user_droplet_fuzzy_name" => name
+      })
+    end
   end
 end
 

--- a/lib/tugboat/middleware.rb
+++ b/lib/tugboat/middleware.rb
@@ -19,6 +19,7 @@ module Tugboat
     autoload :DestroyDroplet, "tugboat/middleware/destroy_droplet"
     autoload :ConfirmAction, "tugboat/middleware/confirm_action"
     autoload :SnapshotDroplet, "tugboat/middleware/snapshot_droplet"
+    autoload :ResizeDroplet, "tugboat/middleware/resize_droplet"
     autoload :ListImages, "tugboat/middleware/list_images"
     autoload :ListSSHKeys, "tugboat/middleware/list_ssh_keys"
     autoload :ListRegions, "tugboat/middleware/list_regions"
@@ -178,6 +179,17 @@ module Tugboat
         use CheckConfiguration
         use InjectClient
         use ListSizes
+      end
+    end
+
+    # Resize a droplet
+    def self.sequence_resize_droplet
+      ::Middleware::Builder.new do
+        use InjectConfiguration
+        use CheckConfiguration
+        use InjectClient
+        use FindDroplet
+        use ResizeDroplet
       end
     end
   end

--- a/lib/tugboat/middleware/resize_droplet.rb
+++ b/lib/tugboat/middleware/resize_droplet.rb
@@ -1,0 +1,24 @@
+module Tugboat
+  module Middleware
+    class ResizeDroplet < Base
+      def call(env)
+        ocean = env["ocean"]
+
+        say "Queuing resize for #{env["droplet_id"]} #{env["droplet_name"]}...", nil, false
+
+        res = ocean.droplets.resize env["droplet_id"],
+                                    :size_id => env["user_droplet_size"]
+
+        if res.status == "ERROR"
+          say "#{res.status}: #{res.error_message}", :red
+          exit 1
+        end
+
+        say "done", :green
+
+        @app.call(env)
+      end
+    end
+  end
+end
+

--- a/spec/cli/resize_cli_spec.rb
+++ b/spec/cli/resize_cli_spec.rb
@@ -1,0 +1,82 @@
+require 'spec_helper'
+
+describe Tugboat::CLI do
+  include_context "spec"
+
+  describe "resize" do
+    it "resizes a droplet with a fuzzy name" do
+      stub_request(:get, "https://api.digitalocean.com/droplets?api_key=#{api_key}&client_id=#{client_key}").
+        to_return(:status => 200, :body => fixture("show_droplets"))
+      stub_request(:get, "https://api.digitalocean.com/droplets/100823/resize?api_key=#{api_key}&client_id=#{client_key}&size_id=123").
+        to_return(:status => 200, :body => '{"status":"OK","event_id":456}')
+
+      @cli.options = @cli.options.merge(:size => 123)
+      @cli.resize("foo")
+
+      expect($stdout.string).to eq <<-eos
+Droplet fuzzy name provided. Finding droplet ID...done\e[0m, 100823 (foo)
+Queuing resize for 100823 (foo)...done
+      eos
+
+      expect(a_request(:get, "https://api.digitalocean.com/droplets?api_key=#{api_key}&client_id=#{client_key}")).
+        to have_been_made
+      expect(a_request(:get, "https://api.digitalocean.com/droplets/100823/resize?api_key=#{api_key}&client_id=#{client_key}&size_id=123")).
+        to have_been_made
+    end
+
+    it "resizes a droplet with an id" do
+      stub_request(:get, "https://api.digitalocean.com/droplets/100823?api_key=#{api_key}&client_id=#{client_key}").
+        to_return(:status => 200, :body => fixture("show_droplet"))
+      stub_request(:get, "https://api.digitalocean.com/droplets/100823/resize?api_key=#{api_key}&client_id=#{client_key}&size_id=123").
+        to_return(:status => 200, :body => '{"status":"OK","event_id":456}')
+
+      @cli.options = @cli.options.merge(:size => 123, :id => 100823)
+      @cli.resize
+
+      expect($stdout.string).to eq <<-eos
+Droplet id provided. Finding Droplet...done\e[0m, 100823 (foo)
+Queuing resize for 100823 (foo)...done
+      eos
+
+      expect(a_request(:get, "https://api.digitalocean.com/droplets/100823?api_key=#{api_key}&client_id=#{client_key}")).
+        to have_been_made
+      expect(a_request(:get, "https://api.digitalocean.com/droplets/100823/resize?api_key=#{api_key}&client_id=#{client_key}&size_id=123")).
+        to have_been_made
+    end
+
+    it "resizes a droplet with a name" do
+      stub_request(:get, "https://api.digitalocean.com/droplets?api_key=#{api_key}&client_id=#{client_key}").
+        to_return(:status => 200, :body => fixture("show_droplets"))
+      stub_request(:get, "https://api.digitalocean.com/droplets/100823/resize?api_key=#{api_key}&client_id=#{client_key}&size_id=123").
+        to_return(:status => 200, :body => '{"status":"OK","event_id":456}')
+
+      @cli.options = @cli.options.merge(:size => 123, :name => "foo")
+      @cli.resize
+
+      expect($stdout.string).to eq <<-eos
+Droplet name provided. Finding droplet ID...done\e[0m, 100823 (foo)
+Queuing resize for 100823 (foo)...done
+      eos
+
+      expect(a_request(:get, "https://api.digitalocean.com/droplets?api_key=#{api_key}&client_id=#{client_key}")).
+        to have_been_made
+      expect(a_request(:get, "https://api.digitalocean.com/droplets/100823/resize?api_key=#{api_key}&client_id=#{client_key}&size_id=123")).
+        to have_been_made
+    end
+
+    it "raises SystemExit when a request fails" do
+      stub_request(:get, "https://api.digitalocean.com/droplets?api_key=#{api_key}&client_id=#{client_key}").
+        to_return(:status => 200, :body => fixture("show_droplets"))
+      stub_request(:get, "https://api.digitalocean.com/droplets/100823/resize?api_key=#{api_key}&client_id=#{client_key}&size_id=123").
+        to_return(:status => 500, :body => '{"status":"ERROR","message":"Some error"}')
+
+      @cli.options = @cli.options.merge(:size => 123)
+      expect { @cli.resize("foo") }.to raise_error(SystemExit)
+
+      expect(a_request(:get, "https://api.digitalocean.com/droplets?api_key=#{api_key}&client_id=#{client_key}")).
+        to have_been_made
+      expect(a_request(:get, "https://api.digitalocean.com/droplets/100823/resize?api_key=#{api_key}&client_id=#{client_key}&size_id=123")).
+        to have_been_made
+    end
+  end
+end


### PR DESCRIPTION
Since there is only one API option (`size_id`) and it is required, perhaps the syntax should be like it is for `snapshot`. Although it would feel more natural to say `resize fuzzy_name new_name` instead. In any case, I used `create`'s syntax here as a start.
