### PR TITLE
Improves droplets list/info prints

### DIFF
--- a/lib/tugboat/config.rb
+++ b/lib/tugboat/config.rb
@@ -10,12 +10,36 @@ module Tugboat
     attr_reader :path
 
     FILE_NAME = '.tugboat'
+
     DEFAULT_SSH_KEY_PATH = '.ssh/id_rsa'
-    DEFAULT_SSH_PORT = '22'
-    DEFAULT_REGION = '1'
-    DEFAULT_IMAGE = '284203'
-    DEFAULT_SIZE = '66'
-    DEFAULT_SSH_KEY = ''
+    DEFAULT_SSH_PORT     = '22'
+    DEFAULT_SSH_KEY      = ''
+
+    DEFAULT_REGION   = '1'
+    DEFAULT_IMAGE    = '284203'
+    DEFAULT_SIZE     = '66'
+
+    # DEFAULT_SORT_BY  = 'name' # droplet#name, ip, region, status...
+
+    REGION_NAMES = {
+      1 => 'New York 1',
+      2 => 'Amsterdam',
+      3 => 'San Francisco 1',
+      4 => 'New York 2'
+    }
+
+    SIZE_NAMES = {
+      66 => "512MB",
+      63 => "1GB",
+      62 => "2GB",
+      64 => "4GB",
+      65 => "8GB",
+      61 => "16GB",
+      60 => "32GB",
+      70 => "48GB",
+      69 => "64GB",
+      68 => "96GB"
+    }
 
     def initialize
       @path = ENV["TUGBOAT_CONFIG_PATH"] || File.join(File.expand_path("~"), FILE_NAME)
@@ -111,9 +135,9 @@ module Tugboat
       require 'yaml'
       File.open(@path, File::RDWR|File::TRUNC|File::CREAT, 0600) do |file|
         data = {
-                "authentication" => { "client_key" => client, "api_key" => api },
-                "ssh" => { "ssh_user" => ssh_user, "ssh_key_path" => ssh_key_path , "ssh_port" => ssh_port},
-                "defaults" => { "region" => region, "image" => image, "size" => size, "ssh_key" => ssh_key }
+                'authentication' => { 'client_key' => client, 'api_key' => api },
+                'ssh' => { 'ssh_user' => ssh_user, 'ssh_key_path' => ssh_key_path , 'ssh_port' => ssh_port },
+                'defaults' => { 'region' => region, 'image' => image, 'size' => size, 'ssh_key' => ssh_key }
               }
         file.write data.to_yaml
       end

--- a/lib/tugboat/middleware/info_droplet.rb
+++ b/lib/tugboat/middleware/info_droplet.rb
@@ -19,14 +19,17 @@ module Tugboat
             status_color = RED
           end
 
+        region_name = Configuration::REGION_NAMES[droplet.region_id]
+        size_name = Configuration::SIZE_NAMES[droplet.size_id]
+
         say
+        say "Status:           #{status_color}#{droplet.status}#{CLEAR}"
         say "Name:             #{droplet.name}"
         say "ID:               #{droplet.id}"
-        say "Status:           #{status_color}#{droplet.status}#{CLEAR}"
         say "IP:               #{droplet.ip_address}"
-        say "Region ID:        #{droplet.region_id}"
+        say "Region ID:        #{droplet.region_id} (#{region_name})"
         say "Image ID:         #{droplet.image_id}"
-        say "Size ID:          #{droplet.size_id}"
+        say "Size ID:          #{droplet.size_id} (#{size_name})"
         say "Backups Active:   #{droplet.backups_active || false}"
 
         @app.call(env)
@@ -34,4 +37,3 @@ module Tugboat
     end
   end
 end
-

--- a/lib/tugboat/middleware/list_droplets.rb
+++ b/lib/tugboat/middleware/list_droplets.rb
@@ -2,6 +2,22 @@ module Tugboat
   module Middleware
     # Check if the client has set-up configuration yet.
     class ListDroplets < Base
+
+      def droplet_status(droplet)
+        if droplet.status == "active"
+          ['ON ', GREEN]
+        else
+          ['OFF', RED]
+        end
+      end
+
+      def print_droplet_beautifuly(droplet)
+        status, status_color = droplet_status droplet
+        droplet_name = droplet.name[0,29].ljust(30, ' ')
+        region_name = Configuration::REGION_NAMES[droplet.region_id].ljust(15, ' ')
+        say "#{status_color}#{status}#{CLEAR} #{droplet_name} #{droplet.ip_address.ljust(15, ' ')} @ #{region_name}   ##{droplet.id}"
+      end
+
       def call(env)
         ocean = env["ocean"]
 
@@ -11,15 +27,9 @@ module Tugboat
           say "You don't appear to have any droplets.", :red
           say "Try creating one with #{GREEN}\`tugboat create\`#{CLEAR}"
         else
-          droplet_list.each do |droplet|
-
-            if droplet.status == "active"
-              status_color = GREEN
-            else
-              status_color = RED
-            end
-
-            say "#{droplet.name} (ip: #{droplet.ip_address}, status: #{status_color}#{droplet.status}#{CLEAR}, region: #{droplet.region_id}, id: #{droplet.id})"
+          sort = :name # env["config"].default_sort_by
+          droplet_list.sort_by {|d| d.send(sort) }.each do |droplet|
+            print_droplet_beautifuly droplet
           end
         end
 
@@ -28,4 +38,3 @@ module Tugboat
     end
   end
 end
-

--- a/spec/cli/droplets_cli_spec.rb
+++ b/spec/cli/droplets_cli_spec.rb
@@ -11,9 +11,9 @@ describe Tugboat::CLI do
       @cli.droplets
 
       expect($stdout.string).to eq <<-eos
-test222 (ip: 33.33.33.10, status: \e[32mactive\e[0m, region: 1, id: 100823)
-test223 (ip: 33.33.33.10, status: \e[32mactive\e[0m, region: 1, id: 100823)
-foo (ip: 33.33.33.10, status: \e[32mactive\e[0m, region: 1, id: 100823)
+\e[32mON \e[0m foo                            33.33.33.10     @ New York 1        #100823
+\e[32mON \e[0m test222                        33.33.33.10     @ New York 1        #100823
+\e[32mON \e[0m test223                        33.33.33.10     @ New York 1        #100823
       eos
 
       expect(a_request(:get, "https://api.digitalocean.com/droplets?api_key=#{api_key}&client_id=#{client_key}")).to have_been_made
@@ -35,4 +35,3 @@ Try creating one with \e[32m`tugboat create`\e[0m
   end
 
 end
-

--- a/spec/cli/info_cli_spec.rb
+++ b/spec/cli/info_cli_spec.rb
@@ -16,13 +16,13 @@ describe Tugboat::CLI do
       expect($stdout.string).to eq <<-eos
 Droplet fuzzy name provided. Finding droplet ID...done\e[0m, 100823 (foo)
 
+Status:           \e[32mactive\e[0m
 Name:             foo
 ID:               100823
-Status:           \e[32mactive\e[0m
 IP:               33.33.33.10
-Region ID:        1
+Region ID:        1 (New York 1)
 Image ID:         420
-Size ID:          33
+Size ID:          70 (48GB)
 Backups Active:   false
       eos
 
@@ -43,13 +43,13 @@ Backups Active:   false
       expect($stdout.string).to eq <<-eos
 Droplet id provided. Finding Droplet...done\e[0m, 100823 (foo)
 
+Status:           \e[32mactive\e[0m
 Name:             foo
 ID:               100823
-Status:           \e[32mactive\e[0m
 IP:               33.33.33.10
-Region ID:        1
+Region ID:        1 (New York 1)
 Image ID:         420
-Size ID:          33
+Size ID:          70 (48GB)
 Backups Active:   false
       eos
 
@@ -70,13 +70,13 @@ Backups Active:   false
       expect($stdout.string).to eq <<-eos
 Droplet name provided. Finding droplet ID...done\e[0m, 100823 (foo)
 
+Status:           \e[32mactive\e[0m
 Name:             foo
 ID:               100823
-Status:           \e[32mactive\e[0m
 IP:               33.33.33.10
-Region ID:        1
+Region ID:        1 (New York 1)
 Image ID:         420
-Size ID:          33
+Size ID:          70 (48GB)
 Backups Active:   false
       eos
 

--- a/spec/fixtures/show_droplet.json
+++ b/spec/fixtures/show_droplet.json
@@ -7,7 +7,7 @@
     "name": "foo",
     "ip_address": "33.33.33.10",
     "region_id": 1,
-    "size_id": 33,
+    "size_id": 70,
     "status": "active"
   }
 }


### PR DESCRIPTION
Hi there,  I've made a fancy listing for droplets:

Before:

```
xxxx (ip: 16.213.16.14, status: active, region: 4, id: 123456)
rock (ip: 16.213.36.1, status: active, region: 4, id: 123456)
aaab (ip: 16.213.17.111, status: off, region: 4, id: 123456)
```

After:

```
ON   aaab                 16.213.17.111    @ New York 2      #123456
OFF  rock                 16.213.17.1      @ New York 2      #123456
....
```

It's the beginning of a plan to display my servers sanely... sort (by name for now) and group.
I'll follow up with a issue so we can discuss grouping the droplets ;)
