### PR TITLE
require json at the top to avoid 2.0.0 issues

### DIFF
--- a/lib/tugboat.rb
+++ b/lib/tugboat.rb
@@ -1,6 +1,7 @@
 require 'tugboat/cli'
 require "tugboat/config"
 require "tugboat/version"
+require 'json'
 
 module Tugboat
 end


### PR DESCRIPTION
This should fix #79, I was getting this as well with `ruby 2.0.0p247 (2013-06-27 revision 41674) [x86_64-darwin12.3.0]`

I don't really know how Ruby stuff like this works so I would appreciate opinions. :)
