### PR TITLE
Add backups_enabled option on droplet creation (-b true)

### DIFF
--- a/lib/tugboat/cli.rb
+++ b/lib/tugboat/cli.rb
@@ -120,6 +120,10 @@ module Tugboat
                   :type => :boolean,
                   :aliases => "-p",
                   :desc => "Enable private networking on the droplet"
+    method_option  "backups_enabled",
+                   :type => :boolean,
+                   :aliases => "-b",
+                   :desc => "Enable backups on the droplet"
 
     def create(name)
       Middleware.sequence_create_droplet.call({
@@ -128,6 +132,7 @@ module Tugboat
         "create_droplet_region_id" => options[:region],
         "create_droplet_ssh_key_ids" => options[:keys],
         "create_droplet_private_networking" => options[:private_networking],
+        "create_droplet_backups_enabled" => options[:backups_enabled],
         "create_droplet_name" => name
       })
     end

--- a/lib/tugboat/config.rb
+++ b/lib/tugboat/config.rb
@@ -17,6 +17,7 @@ module Tugboat
     DEFAULT_SIZE = '66'
     DEFAULT_SSH_KEY = ''
     DEFAULT_PRIVATE_NETWORKING = 'false'
+    DEFAULT_BACKUPS_ENABLED = 'false'
 
     def initialize
       @path = ENV["TUGBOAT_CONFIG_PATH"] || File.join(File.expand_path("~"), FILE_NAME)
@@ -72,6 +73,10 @@ module Tugboat
       @data['defaults'].nil? ? DEFAULT_PRIVATE_NETWORKING : @data['defaults']['private_networking']
     end
 
+    def default_backups_enabled
+      @data['defaults'].nil? ? DEFAULT_BACKUPS_ENABLED : @data['defaults']['backups_enabled']
+    end
+
     # Re-runs initialize
     def reset!
       self.send(:initialize)
@@ -83,7 +88,7 @@ module Tugboat
     end
 
     # Writes a config file
-    def create_config_file(client, api, ssh_key_path, ssh_user, ssh_port, region, image, size, ssh_key, private_networking)
+    def create_config_file(client, api, ssh_key_path, ssh_user, ssh_port, region, image, size, ssh_key, private_networking, backups_enabled)
       # Default SSH Key path
       if ssh_key_path.empty?
         ssh_key_path = File.join(File.expand_path("~"), DEFAULT_SSH_KEY_PATH)
@@ -117,6 +122,10 @@ module Tugboat
         private_networking = DEFAULT_PRIVATE_NETWORKING
       end
 
+      if backups_enabled.empty?
+        backups_enabled = DEFAULT_BACKUPS_ENABLED
+      end
+
       require 'yaml'
       File.open(@path, File::RDWR|File::TRUNC|File::CREAT, 0600) do |file|
         data = {
@@ -132,7 +141,8 @@ module Tugboat
                   "image" => image,
                   "size" => size,
                   "ssh_key" => ssh_key,
-                  "private_networking" => private_networking
+                  "private_networking" => private_networking,
+                  "backups_enabled" => backups_enabled
                 }
         }
         file.write data.to_yaml

--- a/lib/tugboat/middleware/ask_for_credentials.rb
+++ b/lib/tugboat/middleware/ask_for_credentials.rb
@@ -19,9 +19,10 @@ module Tugboat
         size     = ask "Enter your default size ID (optional, defaults to 66 (512MB)):"
         ssh_key  = ask "Enter your default ssh key ID (optional, defaults to none):"
         private_networking = ask "Enter your default for private networking (optional, defaults to false):"
+        backups_enabled = ask "Enter your default for enabling backups (optional, defaults to false):"
 
         # Write the config file.
-        env['config'].create_config_file(client_key, api_key, ssh_key_path, ssh_user, ssh_port, region, image, size, ssh_key, private_networking)
+        env['config'].create_config_file(client_key, api_key, ssh_key_path, ssh_user, ssh_port, region, image, size, ssh_key, private_networking, backups_enabled)
         env['config'].reload!
 
         @app.call(env)

--- a/lib/tugboat/middleware/create_droplet.rb
+++ b/lib/tugboat/middleware/create_droplet.rb
@@ -26,12 +26,18 @@ module Tugboat
             droplet_private_networking = env["create_droplet_private_networking"] :
             droplet_private_networking = env["config"].default_private_networking
 
+        env["create_droplet_backups_enabled"] ?
+            droplet_backups_enabled = env["create_droplet_backups_enabled"] :
+            droplet_backups_enabled = env["config"].default_backups_enabled
+
+
         req = ocean.droplets.create :name               => env["create_droplet_name"],
                                     :size_id            => droplet_size_id,
                                     :image_id           => droplet_image_id,
                                     :region_id          => droplet_region_id,
                                     :ssh_key_ids        => droplet_ssh_key_id,
-                                    :private_networking => droplet_private_networking
+                                    :private_networking => droplet_private_networking,
+                                    :backups_enabled    => droplet_backups_enabled
 
         if req.status == "ERROR"
           say req.error_message, :red

--- a/spec/cli/authorize_cli_spec.rb
+++ b/spec/cli/authorize_cli_spec.rb
@@ -34,12 +34,15 @@ describe Tugboat::CLI do
       $stdin.should_receive(:gets).and_return(ssh_key_id)
       $stdout.should_receive(:print).with("Enter your default for private networking (optional, defaults to false): ")
       $stdin.should_receive(:gets).and_return(private_networking)
+      $stdout.should_receive(:print).with("Enter your default for enabling backups (optional, defaults to false): ")
+      $stdin.should_receive(:gets).and_return(backups_enabled)
+
 
       @cli.authorize
 
       expect(a_request(:get, "https://api.digitalocean.com/droplets?api_key=#{api_key}&client_id=#{client_key}")).to have_been_made
 
-      File.read(tmp_path).should include "image: '#{image}'", "region: '#{region}'", "size: '#{size}'", "ssh_user: #{ssh_user}", "ssh_key_path: #{ssh_key_path}", "ssh_port: '#{ssh_port}'", "ssh_key: '#{ssh_key_id}'", "private_networking: '#{private_networking}'"
+      File.read(tmp_path).should include "image: '#{image}'", "region: '#{region}'", "size: '#{size}'", "ssh_user: #{ssh_user}", "ssh_key_path: #{ssh_key_path}", "ssh_port: '#{ssh_port}'", "ssh_key: '#{ssh_key_id}'", "private_networking: '#{private_networking}'", "backups_enabled: '#{backups_enabled}'"
 
     end
 
@@ -66,6 +69,9 @@ describe Tugboat::CLI do
       $stdin.should_receive(:gets).and_return('')
       $stdout.should_receive(:print).with("Enter your default for private networking (optional, defaults to false): ")
       $stdin.should_receive(:gets).and_return('')
+      $stdout.should_receive(:print).with("Enter your default for enabling backups (optional, defaults to false): ")
+      $stdin.should_receive(:gets).and_return('')
+
 
       @cli.authorize
 

--- a/spec/cli/create_cli_spec.rb
+++ b/spec/cli/create_cli_spec.rb
@@ -5,7 +5,7 @@ describe Tugboat::CLI do
 
   describe "create a droplet" do
     it "with a name, uses defaults from configuration" do
-      stub_request(:get, "https://api.digitalocean.com/droplets/new?api_key=#{api_key}&client_id=#{client_key}&image_id=#{image}&name=#{droplet_name}&private_networking=#{private_networking}&region_id=#{region}&size_id=#{size}&ssh_key_ids=#{ssh_key_id}").
+      stub_request(:get, "https://api.digitalocean.com/droplets/new?api_key=#{api_key}&client_id=#{client_key}&image_id=#{image}&name=#{droplet_name}&backups_enabled=#{backups_enabled}&private_networking=#{private_networking}&region_id=#{region}&size_id=#{size}&ssh_key_ids=#{ssh_key_id}").
          to_return(:status => 200, :body => '{"status":"OK"}')
 
       @cli.create(droplet_name)
@@ -13,11 +13,11 @@ describe Tugboat::CLI do
       expect($stdout.string).to eq <<-eos
 Queueing creation of droplet '#{droplet_name}'...done
       eos
-      expect(a_request(:get, "https://api.digitalocean.com/droplets/new?api_key=#{api_key}&client_id=#{client_key}&image_id=#{image}&name=#{droplet_name}&private_networking=#{private_networking}&region_id=#{region}&size_id=#{size}&ssh_key_ids=#{ssh_key_id}")).to have_been_made
+      expect(a_request(:get, "https://api.digitalocean.com/droplets/new?api_key=#{api_key}&client_id=#{client_key}&image_id=#{image}&name=#{droplet_name}&backups_enabled=#{backups_enabled}&private_networking=#{private_networking}&region_id=#{region}&size_id=#{size}&ssh_key_ids=#{ssh_key_id}")).to have_been_made
     end
 
     it "with args does not use defaults from configuration" do
-      stub_request(:get, "https://api.digitalocean.com/droplets/new?api_key=#{api_key}&client_id=#{client_key}&image_id=555&name=foo&private_networking=#{private_networking}&region_id=3&size_id=666&ssh_key_ids=4321").
+      stub_request(:get, "https://api.digitalocean.com/droplets/new?api_key=#{api_key}&client_id=#{client_key}&image_id=555&name=foo&backups_enabled=#{backups_enabled}&private_networking=#{private_networking}&region_id=3&size_id=666&ssh_key_ids=4321").
          to_return(:status => 200, :body => '{"status":"OK"}')
 
       @cli.options = @cli.options.merge(:image => '555', :size => '666', :region => '3', :keys => '4321')
@@ -27,7 +27,7 @@ Queueing creation of droplet '#{droplet_name}'...done
 Queueing creation of droplet '#{droplet_name}'...done
       eos
 
-      expect(a_request(:get, "https://api.digitalocean.com/droplets/new?api_key=#{api_key}&client_id=#{client_key}&image_id=555&name=foo&private_networking=#{private_networking}&region_id=3&size_id=666&ssh_key_ids=4321")).to have_been_made
+      expect(a_request(:get, "https://api.digitalocean.com/droplets/new?api_key=#{api_key}&client_id=#{client_key}&image_id=555&name=foo&backups_enabled=#{backups_enabled}&private_networking=#{private_networking}&region_id=3&size_id=666&ssh_key_ids=4321")).to have_been_made
     end
   end
 

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -33,12 +33,13 @@ describe Tugboat::Configuration do
     let(:size)               { "66" }
     let(:ssh_key_id)         { '1234' }
     let(:private_networking) { 'true' }
+    let(:backups_enabled)    { 'true' }
 
     let(:config)           { config = Tugboat::Configuration.instance }
 
     before :each do
       # Create a temporary file
-      config.create_config_file(client_key, api_key, ssh_key_path, ssh_user, ssh_port, region, image, size, ssh_key_id, private_networking)
+      config.create_config_file(client_key, api_key, ssh_key_path, ssh_user, ssh_port, region, image, size, ssh_key_id, private_networking, backups_enabled)
     end
 
     it "can be created" do
@@ -90,6 +91,11 @@ describe Tugboat::Configuration do
       private_networking = data["defaults"]
       expect(private_networking).to have_key("private_networking")
     end
+
+    it "should have backups_enabled set" do
+      backups_enabled = data["defaults"]
+      expect(backups_enabled).to have_key("backups_enabled")
+    end
   end
   describe "backwards compatible" do
     let(:client_key)       { "foo" }
@@ -104,6 +110,7 @@ describe Tugboat::Configuration do
     let(:config_default_size)       { Tugboat::Configuration::DEFAULT_SIZE }
     let(:config_default_ssh_key)    { Tugboat::Configuration::DEFAULT_SSH_KEY }
     let(:config_default_networking) { Tugboat::Configuration::DEFAULT_PRIVATE_NETWORKING }
+    let(:config_default_backups)    { Tugboat::Configuration::DEFAULT_BACKUPS_ENABLED }
     let(:backwards_config) {
       {
                 "authentication" => { "client_key" => client_key, "api_key" => api_key },
@@ -143,6 +150,11 @@ describe Tugboat::Configuration do
     it "should use default private networking option if not in configuration" do
       private_networking = config.default_private_networking
       expect(private_networking).to eql config_default_networking
+    end
+
+    it "should use default backups_enabled if not in the configuration" do
+      backups_enabled = config.default_backups_enabled
+      expect(backups_enabled).to eql config_default_backups
     end
 
   end

--- a/spec/shared/environment.rb
+++ b/spec/shared/environment.rb
@@ -18,6 +18,7 @@ shared_context "spec" do
   let(:ssh_key_name)       { 'macbook_pro' }
   let(:ssh_public_key)     { 'ssh-dss A123= user@host' }
   let(:private_networking) { 'false'}
+  let(:backups_enabled)    { 'false'}
   let(:ocean)              { DigitalOcean::API.new :client_id => client_key, :api_key =>api_key }
   let(:app)                { lambda { |env| } }
   let(:env)                { {} }
@@ -29,7 +30,7 @@ shared_context "spec" do
     @cli = Tugboat::CLI.new
 
     # Set a temprary project path and create fake config.
-    config.create_config_file(client_key, api_key, ssh_key_path, ssh_user, ssh_port, region, image, size, ssh_key_id, private_networking)
+    config.create_config_file(client_key, api_key, ssh_key_path, ssh_user, ssh_port, region, image, size, ssh_key_id, private_networking, backups_enabled)
     config.reload!
 
     # Keep track of the old stderr / out


### PR DESCRIPTION
Hey there,

I've added an option for creating a droplet with the new backups_enabled (added to the digital ocean api yesterday) parameter. See https://developers.digitalocean.com/ for the (spartan) details.

Thanks!
