### PR TITLE
Update the link to get v1 API keys in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Please note that Tugboat version 0.2.0 and up requires Ruby 1.9 or higher.
 ## Configuration
 
 Run the configuration utility, `tugboat authorize`. You can grab your keys
-[here](https://www.digitalocean.com/api_access).
+[here](https://cloud.digitalocean.com/api_access).
 
     $ tugboat authorize
     Enter your client key: foo


### PR DESCRIPTION
Digital Ocean now redirects the previous link to the v2 API documentation.
