### PR TITLE
Enable simplecov HTML formatter and Coveralls

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,12 @@
+require 'simplecov'
 require 'coveralls'
-Coveralls.wear! { add_filter '/spec/' }
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+  SimpleCov::Formatter::HTMLFormatter,
+  Coveralls::SimpleCov::Formatter
+]
+SimpleCov.start do
+  coverage_dir('coverage/')
+end
 
 require 'tugboat'
 require 'webmock/rspec'


### PR DESCRIPTION
Much easier to check a local index file than open a browser window for Coveralls
