### PR TITLE
Adds slugs to regions list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,9 +155,9 @@ Optionally, list images provided by DigitalOcean as well.
 
     $ tugboat regions
     Regions:
-    New York 1 (id: 1)
-    Amsterdam 1 (id: 2)
-    San Francisco 1 (id: 3)
+    New York 1 (id: 1) (slug: nyc1)
+    Amsterdam 1 (id: 2) (slug: ams1)
+    San Francisco 1 (id: 3) (slug: sfo1)
 
 ### List SSH Keys
 
@@ -190,7 +190,7 @@ ask tugboat about it.
 For a complete overview of all of the available commands, run:
 
     $ tugboat help
-    
+
 
 Depending on your local configuration, you may need to install a CA bundle (OS X only) using [homebrew](http://brew.sh/) to commmunicate with DigitalOcean through SSL/TLS:
 

--- a/lib/tugboat/middleware/list_regions.rb
+++ b/lib/tugboat/middleware/list_regions.rb
@@ -7,7 +7,7 @@ module Tugboat
 
         say "Regions:"
         regions.each do |region|
-          say "#{region.name} (id: #{region.id})"
+          say "#{region.name} (id: #{region.id}) (slug: #{region.slug})"
         end
 
         @app.call(env)

--- a/spec/cli/regions_cli_spec.rb
+++ b/spec/cli/regions_cli_spec.rb
@@ -12,9 +12,9 @@ describe Tugboat::CLI do
 
       expect($stdout.string).to eq <<-eos
 Regions:
-Region 1 (id: 1)
-Region 2 (id: 2)
-Region 3 (id: 3)
+Region 1 (id: 1) (slug: reg1)
+Region 2 (id: 2) (slug: reg2)
+Region 3 (id: 3) (slug: reg3)
       eos
 
       expect(a_request(:get, "https://api.digitalocean.com/regions?api_key=#{api_key}&client_id=#{client_key}")).

--- a/spec/fixtures/show_regions.json
+++ b/spec/fixtures/show_regions.json
@@ -3,15 +3,18 @@
   "regions": [
     {
       "id": 1,
-      "name": "Region 1"
+      "name": "Region 1",
+      "slug": "reg1"
     },
     {
       "id": 2,
-      "name": "Region 2"
+      "name": "Region 2",
+      "slug": "reg2"
     },
     {
       "id": 3,
-      "name": "Region 3"
+      "name": "Region 3",
+      "slug": "reg3"
     }
   ]
 }


### PR DESCRIPTION
The API returns the 'slug' name for the regions. This displays them when calling:

```
tugboat regions
```
