### PR TITLE
fix API URL in cli.rb

### DIFF
--- a/lib/tugboat/cli.rb
+++ b/lib/tugboat/cli.rb
@@ -28,7 +28,7 @@ module Tugboat
     details to tugboat. First, you are asked for your API and Client keys,
     which are stored in ~/.tugboat.
 
-    You can retrieve your credentials from digitalocean.com/api_access.
+    You can retrieve your credentials from cloud.digitalocean.com/api_access.
 
     Optionally, you can configure the default SSH key path and username
     used for `tugboat ssh`. These default to '~/.ssh/id_rsa' and the


### PR DESCRIPTION
the new URL will take you to the desired information.  This appears to have been fixed in the master branch in other places (as compared to the version you get with `gem install tugboat`, which is currently 0.2.0) but this one spot remains.
