### PR TITLE
region one unavailable on some clients, use NYC 2

### DIFF
--- a/lib/tugboat/config.rb
+++ b/lib/tugboat/config.rb
@@ -12,7 +12,7 @@ module Tugboat
     FILE_NAME = '.tugboat'
     DEFAULT_SSH_KEY_PATH = '.ssh/id_rsa'
     DEFAULT_SSH_PORT = '22'
-    DEFAULT_REGION = '1'
+    DEFAULT_REGION = '4'
     DEFAULT_IMAGE = '3240036'
     DEFAULT_SIZE = '66'
     DEFAULT_SSH_KEY = ''


### PR DESCRIPTION
I could look around later for a default region generator that would look at what that regions subroutine lists, and then pick one of those by default, instead? Then tugboat won't show an error if that region code doesn't exist, because it won't have set it to that.