### PR TITLE
Add configuration option for using the public IP.

### DIFF
--- a/lib/tugboat/config.rb
+++ b/lib/tugboat/config.rb
@@ -53,6 +53,10 @@ module Tugboat
       @data['ssh']['ssh_port']
     end
 
+    def use_public_ip
+      @data['use_public_ip']
+    end
+
     def default_region
       @data['defaults'].nil? ? DEFAULT_REGION : @data['defaults']['region']
     end

--- a/lib/tugboat/middleware/ssh_droplet.rb
+++ b/lib/tugboat/middleware/ssh_droplet.rb
@@ -24,11 +24,22 @@ module Tugboat
         end
 
         ssh_user = env["user_droplet_ssh_user"] || env["config"].ssh_user
-        host_string = "#{ssh_user}@#{env["droplet_ip"]}"
 
-        if env["droplet_ip_private"] and not env["user_droplet_use_public_ip"]
-          host_string = "#{ssh_user}@#{env["droplet_ip_private"]}"
+        host_ip = env["droplet_ip"]
+
+        if env["droplet_ip_private"]
+          use_public_ip = env["config"].use_public_ip
+
+          if not env["user_droplet_use_public_ip"].nil?
+            use_public_ip = env["user_droplet_use_public_ip"]
+          end
+
+          if not use_public_ip
+            host_ip = env["droplet_ip_private"]
+          end
         end
+
+        host_string = "#{ssh_user}@#{host_ip}"
 
         options << host_string
 

--- a/spec/middleware/ssh_droplet_spec.rb
+++ b/spec/middleware/ssh_droplet_spec.rb
@@ -50,6 +50,25 @@ describe Tugboat::Middleware::SSHDroplet do
       described_class.new(app).call(env)
     end
 
+    it "executes ssh using public ip setting from config" do
+      config.data["use_public_ip"] = true
+
+      expect(Kernel).to receive(:exec).with("ssh",
+                        "-o", "IdentitiesOnly=yes",
+                        "-o", "LogLevel=ERROR",
+                        "-o", "StrictHostKeyChecking=no",
+                        "-o", "UserKnownHostsFile=/dev/null",
+                        "-i", ssh_key_path,
+                        "-p", ssh_port,
+                        "#{ssh_user}@#{droplet_ip}")
+
+      env["droplet_ip"] = droplet_ip
+      env["droplet_ip_private"] = droplet_ip_private
+      env["config"] = config
+
+      described_class.new(app).call(env)
+    end
+
   end
 
 end


### PR DESCRIPTION
This can still be overridden with the `-e` flag to `ssh`.  The default isn't changed, so users have to explicitly add the option `use_public_ip` to their configuration file.

I wasn't sure about whether it should also be added to the initial configuration file, so I have left that part out.

There is also one additional test case to verify the new configuration option.