### PR TITLE
Resolve the SSH key path later.

### DIFF
--- a/lib/tugboat/config.rb
+++ b/lib/tugboat/config.rb
@@ -91,7 +91,7 @@ module Tugboat
     def create_config_file(client, api, ssh_key_path, ssh_user, ssh_port, region, image, size, ssh_key, private_networking, backups_enabled)
       # Default SSH Key path
       if ssh_key_path.empty?
-        ssh_key_path = File.join(File.expand_path("~"), DEFAULT_SSH_KEY_PATH)
+        ssh_key_path = File.join("~", DEFAULT_SSH_KEY_PATH)
       end
 
       if ssh_user.empty?

--- a/lib/tugboat/middleware/ssh_droplet.rb
+++ b/lib/tugboat/middleware/ssh_droplet.rb
@@ -9,7 +9,7 @@ module Tugboat
           "-o", "LogLevel=ERROR",
           "-o", "StrictHostKeyChecking=no",
           "-o", "UserKnownHostsFile=/dev/null",
-          "-i", env["config"].ssh_key_path.to_s]
+          "-i", File.expand_path(env["config"].ssh_key_path.to_s)]
 
         if env["user_droplet_ssh_port"]
           options.push("-p", env["user_droplet_ssh_port"].to_s)

--- a/spec/middleware/ssh_droplet_spec.rb
+++ b/spec/middleware/ssh_droplet_spec.rb
@@ -15,7 +15,7 @@ describe Tugboat::Middleware::SSHDroplet do
                         "-o", "LogLevel=ERROR",
                         "-o", "StrictHostKeyChecking=no",
                         "-o", "UserKnownHostsFile=/dev/null",
-                        "-i", ssh_key_path,
+                        "-i", File.expand_path(ssh_key_path),
                         "-p", ssh_port,
                         "#{ssh_user}@#{droplet_ip_private}")
 
@@ -32,7 +32,7 @@ describe Tugboat::Middleware::SSHDroplet do
                         "-o", "LogLevel=ERROR",
                         "-o", "StrictHostKeyChecking=no",
                         "-o", "UserKnownHostsFile=/dev/null",
-                        "-i", ssh_key_path,
+                        "-i", File.expand_path(ssh_key_path),
                         "-p", ssh_port,
                         "-e",
                         "-q",


### PR DESCRIPTION
This enables the user to use e.g. "~/.ssh/id_rsa"` in their configuration file, thereby solving issue https://github.com/pearkes/tugboat/issues/130 and https://github.com/pearkes/tugboat/issues/105.

@brandondrew does this work for you? I don't think generally allowing environment variables in the configuration file is necessary, as `"~"` is enough here, so I just went with that.