### PR TITLE
Update docs to clarify add-key command

### DIFF
--- a/lib/tugboat/cli.rb
+++ b/lib/tugboat/cli.rb
@@ -359,7 +359,10 @@ module Tugboat
       Middleware.sequence_ssh_keys.call({})
     end
 
-    desc "add-key NAME", "Upload an ssh public key."
+    desc "add-key KEY-NAME", "Upload an ssh public key to DigitalOcean, to be assigned to a droplet later"
+    long_desc "This uploads a ssh-key to DigitalOcean, which you can then assign to a droplet at
+    creation time so you can connect to it with the key rather than a password.
+    "
     method_option  "key",
                    :type => :string,
                    :aliases => "-k",


### PR DESCRIPTION
There seems to be some confusion around the add-key command, as it just uploads a key to DigitalOcean, not to a machine (See #136, #146)