### PR TITLE
Implement single attribute fetcher and porcelain mode for droplet info command

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,24 @@ match.
     Size ID:          66
     Backups Active:   false
 
+Print info in machine-readable format. The ``--porcelain`` flag silences extra output for easy parsing. Fuzzy name matching is not supported with the ``--porcelain`` flag.
+
+    $ tugboat info -n pearkes-admin-001 --attribute ip --porcelain
+    name pearkes-admin-001
+    id 13231512
+    status active
+    ip 30.30.30.3
+    region_id 1
+    image_id 25489
+    size_id 66
+    backups_active false
+
+Print a single attribute.
+
+    $ tugboat info -n pearkes-admin-001 --attribute ip --porcelain
+    30.30.30.3
+
+
 ### Destroy a droplet
 
     $ tugboat destroy pearkes-www-002

--- a/lib/tugboat/cli.rb
+++ b/lib/tugboat/cli.rb
@@ -308,12 +308,21 @@ module Tugboat
                   :type => :string,
                   :aliases => "-n",
                   :desc => "The exact name of the droplet"
+    method_option "attribute",
+                  :type => :string,
+                  :aliases => "-a",
+                  :desc => "The name of the attribute to print."
+    method_option "porcelain",
+                  :type => :boolean,
+                  :desc => "Give the output in an easy-to-parse format for scripts."
     def info(name=nil)
       Middleware.sequence_info_droplet.call({
         "user_droplet_id" => options[:id],
         "user_droplet_name" => options[:name],
         "user_droplet_fuzzy_name" => name,
-        "user_quiet" => options[:quiet]
+        "user_quiet" => options[:quiet],
+        "user_attribute" => options[:attribute],
+        "user_porcelain" => options[:porcelain]
       })
     end
 

--- a/lib/tugboat/middleware/find_droplet.rb
+++ b/lib/tugboat/middleware/find_droplet.rb
@@ -7,11 +7,17 @@ module Tugboat
         user_fuzzy_name = env['user_droplet_fuzzy_name']
         user_droplet_name = env['user_droplet_name']
         user_droplet_id = env['user_droplet_id']
+        porcelain = env['user_porcelain']
 
         # First, if nothing is provided to us, we should quit and
         # let the user know.
         if !user_fuzzy_name && !user_droplet_name && !user_droplet_id
           say "Tugboat attempted to find a droplet with no arguments. Try `tugboat help`", :red
+          exit 1
+        end
+
+        if porcelain && (!(user_droplet_name || user_droplet_id) || user_fuzzy_name)
+          say "Tugboat expects an exact droplet ID or droplet name for porcelain mode.", :red
           exit 1
         end
 
@@ -22,7 +28,9 @@ module Tugboat
 
         # Easy for us if they provide an id. Just set it to the droplet_id
         if user_droplet_id
-          say "Droplet id provided. Finding Droplet...", nil, false
+          if !porcelain
+            say "Droplet id provided. Finding Droplet...", nil, false
+          end
           req = ocean.droplets.show user_droplet_id
 
           if req.status == "ERROR"
@@ -40,7 +48,9 @@ module Tugboat
         # If they provide a name, we need to get the ID for it.
         # This requires a lookup.
         if user_droplet_name && !env["droplet_id"]
-          say "Droplet name provided. Finding droplet ID...", nil, false
+          if !porcelain
+            say "Droplet name provided. Finding droplet ID...", nil, false
+          end
 
           # Look for the droplet by an exact name match.
           ocean.droplets.list.droplets.each do |d|
@@ -115,7 +125,9 @@ module Tugboat
         end
 
         if !did_run_multiple
-          say "done#{CLEAR}, #{env["droplet_id"]} #{env["droplet_name"]}", :green
+          if !porcelain
+            say "done#{CLEAR}, #{env["droplet_id"]} #{env["droplet_name"]}", :green
+          end
         end
         @app.call(env)
       end

--- a/lib/tugboat/middleware/info_droplet.rb
+++ b/lib/tugboat/middleware/info_droplet.rb
@@ -21,17 +21,18 @@ module Tugboat
 
         attribute = env["user_attribute"]
 
-        attributes = {
-          "name" => droplet.name,
-          "id" => droplet.id,
-          "status" => droplet.status,
-          "ip_address" => droplet.ip_address,
-          "private_ip_address" => droplet.private_ip_address,
-          "region_id" => droplet.region_id,
-          "image_id" => droplet.image_id,
-          "size_id" => droplet.size_id,
-          "backups_active" => (droplet.backups_active || false)
-        }
+        attributes_list = [
+          ["name",  droplet.name],
+          ["id",  droplet.id],
+          ["status",  droplet.status],
+          ["ip",  droplet.ip_address],
+          ["private_ip",  droplet.private_ip_address],
+          ["region_id",  droplet.region_id],
+          ["image_id",  droplet.image_id],
+          ["size_id",  droplet.size_id],
+          ["backups_active",  (droplet.backups_active || false)]
+        ]
+        attributes = Hash[*attributes_list.flatten(1)]
 
         if attribute
           if attributes.has_key? attribute
@@ -39,11 +40,11 @@ module Tugboat
           else
             say "Invalid attribute \"#{attribute}\"", :red
             say "Provide one of the following:", :red
-            attributes.keys.each { |a| say "    #{a}", :red }
+            attributes_list.keys.each { |a| say "    #{a[0]}", :red }
           end
         else
           if env["user_porcelain"]
-            attributes.select{ |_, v| v }.each{ |k, v| say "#{k} #{v}"}
+            attributes_list.select{ |a| a[1] != nil }.each{ |a| say "#{a[0]} #{a[1]}"}
           else
             say
             say "Name:             #{droplet.name}"

--- a/lib/tugboat/middleware/info_droplet.rb
+++ b/lib/tugboat/middleware/info_droplet.rb
@@ -19,20 +19,48 @@ module Tugboat
             status_color = RED
           end
 
-        say
-        say "Name:             #{droplet.name}"
-        say "ID:               #{droplet.id}"
-        say "Status:           #{status_color}#{droplet.status}#{CLEAR}"
-        say "IP:               #{droplet.ip_address}"
+        attribute = env["user_attribute"]
 
-        if droplet.private_ip_address
-	        say "Private IP:       #{droplet.private_ip_address}"
-	      end
+        attributes = {
+          "name" => droplet.name,
+          "id" => droplet.id,
+          "status" => droplet.status,
+          "ip_address" => droplet.ip_address,
+          "private_ip_address" => droplet.private_ip_address,
+          "region_id" => droplet.region_id,
+          "image_id" => droplet.image_id,
+          "size_id" => droplet.size_id,
+          "backups_active" => (droplet.backups_active || false)
+        }
 
-        say "Region ID:        #{droplet.region_id}"
-        say "Image ID:         #{droplet.image_id}"
-        say "Size ID:          #{droplet.size_id}"
-        say "Backups Active:   #{droplet.backups_active || false}"
+        if attribute
+          if attributes.has_key? attribute
+            say attributes[attribute]
+          else
+            say "Invalid attribute \"#{attribute}\"", :red
+            say "Provide one of the following:", :red
+            attributes.keys.each { |a| say "    #{a}", :red }
+          end
+        else
+          if env["user_porcelain"]
+            attributes.select{ |_, v| v }.each{ |k, v| say "#{k} #{v}"}
+          else
+            say
+            say "Name:             #{droplet.name}"
+            say "ID:               #{droplet.id}"
+            say "Status:           #{status_color}#{droplet.status}#{CLEAR}"
+            say "IP:               #{droplet.ip_address}"
+
+            if droplet.private_ip_address
+    	        say "Private IP:       #{droplet.private_ip_address}"
+    	      end
+
+            say "Region ID:        #{droplet.region_id}"
+            say "Image ID:         #{droplet.image_id}"
+            say "Size ID:          #{droplet.size_id}"
+            say "Backups Active:   #{droplet.backups_active || false}"
+          end
+        end
 
         @app.call(env)
       end

--- a/spec/cli/info_cli_spec.rb
+++ b/spec/cli/info_cli_spec.rb
@@ -104,7 +104,7 @@ Droplet fuzzy name provided. Finding droplet ID...Multiple droplets found.
 0) test222 (100823)
 1) test223 (100824)
 
-Please choose a droplet: ["0", "1"] 
+Please choose a droplet: ["0", "1"]\x20
 Name:             test222
 ID:               100823
 Status:           \e[32mactive\e[0m
@@ -120,5 +120,129 @@ Backups Active:   false
     end
 
   end
+
+  it "shows a droplet with an id under porcelain mode" do
+      stub_request(:get, "https://api.digitalocean.com/droplets/#{droplet_id}?api_key=#{api_key}&client_id=#{client_key}").
+           to_return(:headers => {'Content-Type' => 'application/json'}, :status => 200, :body => fixture("show_droplet"))
+
+      stub_request(:get, "https://api.digitalocean.com/droplets/100823?api_key=#{api_key}&client_id=#{client_key}").
+           to_return(:headers => {'Content-Type' => 'application/json'}, :status => 200, :body => fixture("show_droplet"))
+
+      @cli.options = @cli.options.merge(:id => droplet_id, :porcelain => true)
+      @cli.info
+
+      expect($stdout.string).to eq <<-eos
+name foo
+id 100823
+status active
+ip_address 33.33.33.10
+private_ip_address 10.20.30.40
+region_id 1
+image_id 420
+size_id 33
+      eos
+
+      expect(a_request(:get, "https://api.digitalocean.com/droplets/100823?api_key=#{api_key}&client_id=#{client_key}")).to have_been_made
+      expect(a_request(:get, "https://api.digitalocean.com/droplets/#{droplet_id}?api_key=#{api_key}&client_id=#{client_key}")).to have_been_made
+    end
+
+    it "shows a droplet with a name under porcelain mode" do
+      stub_request(:get, "https://api.digitalocean.com/droplets?api_key=#{api_key}&client_id=#{client_key}").
+           to_return(:headers => {'Content-Type' => 'application/json'}, :status => 200, :body => fixture("show_droplets"))
+
+      stub_request(:get, "https://api.digitalocean.com/droplets/100823?api_key=#{api_key}&client_id=#{client_key}").
+           to_return(:headers => {'Content-Type' => 'application/json'}, :status => 200, :body => fixture("show_droplet"))
+
+      @cli.options = @cli.options.merge(:name => droplet_name, :porcelain => true)
+      @cli.info
+
+      expect($stdout.string).to eq <<-eos
+name foo
+id 100823
+status active
+ip_address 33.33.33.10
+private_ip_address 10.20.30.40
+region_id 1
+image_id 420
+size_id 33
+      eos
+
+      expect(a_request(:get, "https://api.digitalocean.com/droplets/100823?api_key=#{api_key}&client_id=#{client_key}")).to have_been_made
+      expect(a_request(:get, "https://api.digitalocean.com/droplets?api_key=#{api_key}&client_id=#{client_key}")).to have_been_made
+    end
+
+  it "shows a droplet attribute with an id" do
+    stub_request(:get, "https://api.digitalocean.com/droplets/#{droplet_id}?api_key=#{api_key}&client_id=#{client_key}").
+         to_return(:headers => {'Content-Type' => 'application/json'}, :status => 200, :body => fixture("show_droplet"))
+
+    stub_request(:get, "https://api.digitalocean.com/droplets/100823?api_key=#{api_key}&client_id=#{client_key}").
+         to_return(:headers => {'Content-Type' => 'application/json'}, :status => 200, :body => fixture("show_droplet"))
+
+    @cli.options = @cli.options.merge(:id => droplet_id, :attribute => "ip_address")
+    @cli.info
+
+    expect($stdout.string).to eq <<-eos
+Droplet id provided. Finding Droplet...done\e[0m, 100823 (foo)
+33.33.33.10
+    eos
+
+    expect(a_request(:get, "https://api.digitalocean.com/droplets/100823?api_key=#{api_key}&client_id=#{client_key}")).to have_been_made
+    expect(a_request(:get, "https://api.digitalocean.com/droplets/#{droplet_id}?api_key=#{api_key}&client_id=#{client_key}")).to have_been_made
+  end
+
+  it "shows a droplet attribute with a name" do
+    stub_request(:get, "https://api.digitalocean.com/droplets?api_key=#{api_key}&client_id=#{client_key}").
+         to_return(:headers => {'Content-Type' => 'application/json'}, :status => 200, :body => fixture("show_droplets"))
+
+    stub_request(:get, "https://api.digitalocean.com/droplets/100823?api_key=#{api_key}&client_id=#{client_key}").
+         to_return(:headers => {'Content-Type' => 'application/json'}, :status => 200, :body => fixture("show_droplet"))
+
+    @cli.options = @cli.options.merge(:name => droplet_name, :attribute => "ip_address")
+    @cli.info
+
+    expect($stdout.string).to eq <<-eos
+Droplet name provided. Finding droplet ID...done\e[0m, 100823 (foo)
+33.33.33.10
+    eos
+
+    expect(a_request(:get, "https://api.digitalocean.com/droplets/100823?api_key=#{api_key}&client_id=#{client_key}")).to have_been_made
+    expect(a_request(:get, "https://api.digitalocean.com/droplets?api_key=#{api_key}&client_id=#{client_key}")).to have_been_made
+  end
+
+  it "shows a droplet attribute with an id under porcelain mode" do
+      stub_request(:get, "https://api.digitalocean.com/droplets/#{droplet_id}?api_key=#{api_key}&client_id=#{client_key}").
+           to_return(:headers => {'Content-Type' => 'application/json'}, :status => 200, :body => fixture("show_droplet"))
+
+      stub_request(:get, "https://api.digitalocean.com/droplets/100823?api_key=#{api_key}&client_id=#{client_key}").
+           to_return(:headers => {'Content-Type' => 'application/json'}, :status => 200, :body => fixture("show_droplet"))
+
+      @cli.options = @cli.options.merge(:id => droplet_id, :porcelain => true, :attribute => "ip_address")
+      @cli.info
+
+      expect($stdout.string).to eq <<-eos
+33.33.33.10
+      eos
+
+      expect(a_request(:get, "https://api.digitalocean.com/droplets/100823?api_key=#{api_key}&client_id=#{client_key}")).to have_been_made
+      expect(a_request(:get, "https://api.digitalocean.com/droplets/#{droplet_id}?api_key=#{api_key}&client_id=#{client_key}")).to have_been_made
+    end
+
+    it "shows a droplet attribute with a name under porcelain mode" do
+      stub_request(:get, "https://api.digitalocean.com/droplets?api_key=#{api_key}&client_id=#{client_key}").
+           to_return(:headers => {'Content-Type' => 'application/json'}, :status => 200, :body => fixture("show_droplets"))
+
+      stub_request(:get, "https://api.digitalocean.com/droplets/100823?api_key=#{api_key}&client_id=#{client_key}").
+           to_return(:headers => {'Content-Type' => 'application/json'}, :status => 200, :body => fixture("show_droplet"))
+
+      @cli.options = @cli.options.merge(:name => droplet_name, :porcelain => true, :attribute => "ip_address")
+      @cli.info
+
+      expect($stdout.string).to eq <<-eos
+33.33.33.10
+      eos
+
+      expect(a_request(:get, "https://api.digitalocean.com/droplets/100823?api_key=#{api_key}&client_id=#{client_key}")).to have_been_made
+      expect(a_request(:get, "https://api.digitalocean.com/droplets?api_key=#{api_key}&client_id=#{client_key}")).to have_been_made
+    end
 
 end

--- a/spec/cli/info_cli_spec.rb
+++ b/spec/cli/info_cli_spec.rb
@@ -135,11 +135,12 @@ Backups Active:   false
 name foo
 id 100823
 status active
-ip_address 33.33.33.10
-private_ip_address 10.20.30.40
+ip 33.33.33.10
+private_ip 10.20.30.40
 region_id 1
 image_id 420
 size_id 33
+backups_active false
       eos
 
       expect(a_request(:get, "https://api.digitalocean.com/droplets/100823?api_key=#{api_key}&client_id=#{client_key}")).to have_been_made
@@ -160,11 +161,12 @@ size_id 33
 name foo
 id 100823
 status active
-ip_address 33.33.33.10
-private_ip_address 10.20.30.40
+ip 33.33.33.10
+private_ip 10.20.30.40
 region_id 1
 image_id 420
 size_id 33
+backups_active false
       eos
 
       expect(a_request(:get, "https://api.digitalocean.com/droplets/100823?api_key=#{api_key}&client_id=#{client_key}")).to have_been_made
@@ -178,7 +180,7 @@ size_id 33
     stub_request(:get, "https://api.digitalocean.com/droplets/100823?api_key=#{api_key}&client_id=#{client_key}").
          to_return(:headers => {'Content-Type' => 'application/json'}, :status => 200, :body => fixture("show_droplet"))
 
-    @cli.options = @cli.options.merge(:id => droplet_id, :attribute => "ip_address")
+    @cli.options = @cli.options.merge(:id => droplet_id, :attribute => "ip")
     @cli.info
 
     expect($stdout.string).to eq <<-eos
@@ -197,7 +199,7 @@ Droplet id provided. Finding Droplet...done\e[0m, 100823 (foo)
     stub_request(:get, "https://api.digitalocean.com/droplets/100823?api_key=#{api_key}&client_id=#{client_key}").
          to_return(:headers => {'Content-Type' => 'application/json'}, :status => 200, :body => fixture("show_droplet"))
 
-    @cli.options = @cli.options.merge(:name => droplet_name, :attribute => "ip_address")
+    @cli.options = @cli.options.merge(:name => droplet_name, :attribute => "ip")
     @cli.info
 
     expect($stdout.string).to eq <<-eos
@@ -216,7 +218,7 @@ Droplet name provided. Finding droplet ID...done\e[0m, 100823 (foo)
       stub_request(:get, "https://api.digitalocean.com/droplets/100823?api_key=#{api_key}&client_id=#{client_key}").
            to_return(:headers => {'Content-Type' => 'application/json'}, :status => 200, :body => fixture("show_droplet"))
 
-      @cli.options = @cli.options.merge(:id => droplet_id, :porcelain => true, :attribute => "ip_address")
+      @cli.options = @cli.options.merge(:id => droplet_id, :porcelain => true, :attribute => "ip")
       @cli.info
 
       expect($stdout.string).to eq <<-eos
@@ -234,7 +236,7 @@ Droplet name provided. Finding droplet ID...done\e[0m, 100823 (foo)
       stub_request(:get, "https://api.digitalocean.com/droplets/100823?api_key=#{api_key}&client_id=#{client_key}").
            to_return(:headers => {'Content-Type' => 'application/json'}, :status => 200, :body => fixture("show_droplet"))
 
-      @cli.options = @cli.options.merge(:name => droplet_name, :porcelain => true, :attribute => "ip_address")
+      @cli.options = @cli.options.merge(:name => droplet_name, :porcelain => true, :attribute => "ip")
       @cli.info
 
       expect($stdout.string).to eq <<-eos


### PR DESCRIPTION
This allows a script to easily fetch and parse a single attribute of a
droplet, like an IP address or droplet size.

Examples:
Print info in machine-readable format. The ``--porcelain`` flag silences extra output for easy parsing. Fuzzy name matching is not supported with the ``--porcelain`` flag.

    $ tugboat info -n pearkes-admin-001 --attribute ip --porcelain
    name pearkes-admin-001
    id 13231512
    status active
    ip 30.30.30.3
    region_id 1
    image_id 25489
    size_id 66
    backups_active false

Print a single attribute.

    $ tugboat info -n pearkes-admin-001 --attribute ip --porcelain
    30.30.30.3