### PR TITLE
Removes wrong help messages for `images`.

### DIFF
--- a/lib/tugboat/middleware/list_images.rb
+++ b/lib/tugboat/middleware/list_images.rb
@@ -8,7 +8,7 @@ module Tugboat
           global = ocean.images.list :filter => "global"
         else
           say "Listing Your Images"
-          say "(Use `tugboat images list --global` to show all images)"
+          say "(Use `tugboat images --global` to show all images)"
         end
 
         say "My Images:"

--- a/spec/cli/images_cli_spec.rb
+++ b/spec/cli/images_cli_spec.rb
@@ -12,7 +12,7 @@ describe Tugboat::CLI do
 
       expect($stdout.string).to eq <<-eos
 Listing Your Images
-(Use `tugboat images list --global` to show all images)
+(Use `tugboat images --global` to show all images)
 My Images:
 NYTD Backup 1-18-2012 (id: 466, distro: Ubuntu)
 NLP Final (id: 478, distro: Ubuntu)
@@ -29,7 +29,7 @@ NLP Final (id: 478, distro: Ubuntu)
 
       expect($stdout.string).to eq <<-eos
 Listing Your Images
-(Use `tugboat images list --global` to show all images)
+(Use `tugboat images --global` to show all images)
 My Images:
 No images found
       eos


### PR DESCRIPTION
To show all images, tugboat suggested to run `tugboat images list --global`.
However this returned following error message:

```sh
ERROR: tugboat images was called with arguments ["list"]
Usage: "tugboat images [OPTIONS]".
```

Because calling `tugboat images --global` did return all the images,
this commit removes the invalid `list` argument.