### PR TITLE
Fix interactive prompt during authorize

### DIFF
--- a/lib/tugboat/middleware/ask_for_credentials.rb
+++ b/lib/tugboat/middleware/ask_for_credentials.rb
@@ -5,7 +5,8 @@ module Tugboat
       def call(env)
         say "Note: You can get your Access Token from https://cloud.digitalocean.com/settings/tokens/new", :yellow
         say
-        access_token.strip = ask "Enter your access token:"
+        access_token = ask "Enter your access token:"
+        access_token.strip!
         ssh_key_path = ask "Enter your SSH key path (optional, defaults to ~/.ssh/id_rsa):"
         ssh_user = ask "Enter your SSH user (optional, defaults to root):"
         ssh_port = ask "Enter your SSH port number (optional, defaults to 22):"


### PR DESCRIPTION
While testing the v2 API code, I encountered an uncaught exception related to string trimming:

```
$ tugboat authorize
Note: You can get your Access Token from https://cloud.digitalocean.com/settings/tokens/new

/home/conor/.gem/ruby/2.1.0/gems/tugboat-2.0.0.pre1/lib/tugboat/middleware/ask_for_credentials.rb:8:in `call': undefined local variable or method `access_token' for #<Tugboat::Middleware::AskForCredentials:0x00000001c31d78> (NameError)
        from /home/conor/.gem/ruby/2.1.0/gems/tugboat-2.0.0.pre1/lib/tugboat/middleware/inject_configuration.rb:10:in `call'
        from /home/conor/.gem/ruby/2.1.0/gems/middleware-0.1.0/lib/middleware/runner.rb:31:in `call'
        from /home/conor/.gem/ruby/2.1.0/gems/middleware-0.1.0/lib/middleware/builder.rb:102:in `call'
        from /home/conor/.gem/ruby/2.1.0/gems/tugboat-2.0.0.pre1/lib/tugboat/cli.rb:38:in `authorize'
        from /home/conor/.gem/ruby/2.1.0/gems/thor-0.18.1/lib/thor/command.rb:27:in `run'
        from /home/conor/.gem/ruby/2.1.0/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
        from /home/conor/.gem/ruby/2.1.0/gems/thor-0.18.1/lib/thor.rb:363:in `dispatch'
        from /home/conor/.gem/ruby/2.1.0/gems/thor-0.18.1/lib/thor/base.rb:439:in `start'
        from /home/conor/.gem/ruby/2.1.0/gems/tugboat-2.0.0.pre1/bin/tugboat:10:in `<top (required)>'
        from /home/conor/.gem/ruby/2.1.0/bin/tugboat:23:in `load'
        from /home/conor/.gem/ruby/2.1.0/bin/tugboat:23:in `<main>'
```
A small change to the string handling code fixes the error, and authorization proceeds without a problem. 

It's outside the scope of this patch, but I strongly suggest checking for the `DO_API_TOKEN` environment variable and using that value if it's defined. Happy to implement if that'd be helpful.