### PR TITLE
Add "include_urls" option to "droplets" command

### DIFF
--- a/lib/tugboat/cli.rb
+++ b/lib/tugboat/cli.rb
@@ -66,10 +66,16 @@ module Tugboat
         })
     end
 
-    desc "droplets", "Retrieve a list of your droplets"
+    method_option "include_urls",
+                  :type => :boolean,
+                  :default => false,
+                  :aliases => "-i",
+                  :desc => "Include URLs for the droplets (can be opened in a browser)"
+    desc "droplets [OPTIONS]", "Retrieve a list of your droplets"
     def droplets
       Middleware.sequence_list_droplets.call({
-        "user_quiet" => options[:quiet]
+        "user_quiet" => options[:quiet],
+        "include_urls" => options["include_urls"]
         })
     end
 

--- a/lib/tugboat/middleware/list_droplets.rb
+++ b/lib/tugboat/middleware/list_droplets.rb
@@ -25,11 +25,17 @@ module Tugboat
             end
 
             public_addr = droplet.networks.v4.detect { |address| address.type == 'public' }
-            say "#{droplet.name} (ip: #{public_addr.ip_address}#{private_ip}, status: #{status_color}#{droplet.status}#{CLEAR}, region: #{droplet.region.slug}, id: #{droplet.id})"
+            say "#{droplet.name} (ip: #{public_addr.ip_address}#{private_ip}, status: #{status_color}#{droplet.status}#{CLEAR}, region: #{droplet.region.slug}, id: #{droplet.id}#{env["include_urls"] ? droplet_id_to_url(droplet.id) : '' })"
           end
         end
 
         @app.call(env)
+      end
+
+      private
+
+      def droplet_id_to_url(id)
+        ", url: 'https://cloud.digitalocean.com/droplets/#{id}'"
       end
     end
   end

--- a/spec/cli/droplets_cli_spec.rb
+++ b/spec/cli/droplets_cli_spec.rb
@@ -34,6 +34,7 @@ Try creating one with \e[32m`tugboat create`\e[0m
 
       expect(a_request(:get, "https://api.digitalocean.com/v2/droplets?per_page=200")).to have_been_made
     end
+
     it "shows no output when --quiet is set" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?per_page=200").
          with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
@@ -44,6 +45,23 @@ Try creating one with \e[32m`tugboat create`\e[0m
 
       # Should be /dev/null not stringIO
       expect($stdout).to be_a File
+
+      expect(a_request(:get, "https://api.digitalocean.com/v2/droplets?per_page=200")).to have_been_made
+    end
+
+    it "includes urls when --include-urls is set" do
+      stub_request(:get, "https://api.digitalocean.com/v2/droplets?per_page=200").
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         to_return(:status => 200, :body => fixture("show_droplets"), :headers => {'Content-Type' => 'application/json'},)
+
+      @cli.options = @cli.options.merge("include_urls" => true)
+      @cli.droplets
+
+      expect($stdout.string).to eq <<-eos
+example.com (ip: 104.236.32.182, status: \e[32mactive\e[0m, region: nyc3, id: 6918990, url: 'https://cloud.digitalocean.com/droplets/6918990')
+example2.com (ip: 104.236.32.172, status: \e[32mactive\e[0m, region: nyc3, id: 3164956, url: 'https://cloud.digitalocean.com/droplets/3164956')
+example3.com (ip: 104.236.32.173, status: \e[31moff\e[0m, region: nyc3, id: 3164444, url: 'https://cloud.digitalocean.com/droplets/3164444')
+      eos
 
       expect(a_request(:get, "https://api.digitalocean.com/v2/droplets?per_page=200")).to have_been_made
     end


### PR DESCRIPTION
This allows you to get a URL that can be opened in the browser.  This
defaults to false so it will be no change to existing usage