### PR TITLE
Info droplet API2 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,11 @@ match.
     ID:               13231512
     Status:           active
     IP:               30.30.30.3
-    Region ID:        1
-    Image ID:         25489
-    Size ID:          66
     Backups Active:   false
+    IP6:              2A03:B0C0:0001:00D0:0000:0000:0308:D001
+    Region:           London 1 - lon1
+    Image:            6918990 - ubuntu-14-04-x64
+    Size:             1GB
 
 Print info in machine-readable format. The ``--porcelain`` flag silences extra output for easy parsing. Fuzzy name matching is not supported with the ``--porcelain`` flag.
 
@@ -105,10 +106,10 @@ Print info in machine-readable format. The ``--porcelain`` flag silences extra o
     name pearkes-admin-001
     id 13231512
     status active
-    ip 30.30.30.3
-    region_id 1
-    image_id 25489
-    size_id 66
+    ip4 30.30.30.3
+    region 1
+    image 25489
+    size 66
     backups_active false
 
 Print a single attribute.

--- a/lib/tugboat/middleware/info_droplet.rb
+++ b/lib/tugboat/middleware/info_droplet.rb
@@ -69,8 +69,14 @@ module Tugboat
               say "Private IP:       #{droplet_private_ip}"
             end
 
+            if droplet.image.slug.nil?
+              image_description  = droplet.image.name
+            else
+              image_description = droplet.image.slug
+            end
+
             say "Region:           #{droplet.region.name} - #{droplet.region.slug}"
-            say "Image:            #{droplet.image.id} - #{droplet.image.name}"
+            say "Image:            #{droplet.image.id} - #{image_description}"
             say "Size:             #{droplet.size_slug.upcase}"
             say "Backups Active:   #{!droplet.backup_ids.empty?}"
           end

--- a/lib/tugboat/middleware/info_droplet.rb
+++ b/lib/tugboat/middleware/info_droplet.rb
@@ -39,7 +39,7 @@ module Tugboat
           ["ip6",  droplet_ip6_public],
           ["private_ip",  droplet_private_ip],
           ["region",  droplet.region.slug],
-          ["Image",  droplet.image.id],
+          ["image",  droplet.image.id],
           ["size",  droplet.size_slug],
           ["backups_active",  !droplet.backup_ids.empty?]
         ]

--- a/spec/cli/info_cli_spec.rb
+++ b/spec/cli/info_cli_spec.rb
@@ -24,7 +24,7 @@ Status:           \e[32mactive\e[0m
 IP4:              104.131.186.241
 IP6:              2604:A880:0800:0010:0000:0000:031D:2001
 Region:           New York 3 - nyc3
-Image:            6918990 - 14.04 x64
+Image:            6918990 - ubuntu-14-04-x64
 Size:             512MB
 Backups Active:   false
       eos

--- a/spec/cli/info_cli_spec.rb
+++ b/spec/cli/info_cli_spec.rb
@@ -31,6 +31,29 @@ Backups Active:   false
 
     end
 
+    it "shows a droplet made from a user image" do
+      stub_request(:get, "https://api.digitalocean.com/v2/droplets/6918990?per_page=200").
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         to_return(:status => 200, :body => fixture('show_droplet_user_image'), :headers => {})
+
+      @cli.options = @cli.options.merge(:id => 6918990)
+      @cli.info
+
+      expect($stdout.string).to eq <<-eos
+Droplet id provided. Finding Droplet...done\e[0m, 6918990 (example.com)
+
+Name:             example.com
+ID:               6918990
+Status:           \e[32mactive\e[0m
+IP4:              104.131.186.241
+IP6:              2604:A880:0800:0010:0000:0000:031D:2001
+Region:           New York 3 - nyc3
+Image:            36646276 - Super Cool Custom Image
+Size:             512MB
+Backups Active:   false
+      eos
+    end
+
     it "shows a droplet with an id" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets/6918990?per_page=200").
          with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
@@ -48,7 +71,7 @@ Status:           \e[32mactive\e[0m
 IP4:              104.131.186.241
 IP6:              2604:A880:0800:0010:0000:0000:031D:2001
 Region:           New York 3 - nyc3
-Image:            6918990 - 14.04 x64
+Image:            6918990 - ubuntu-14-04-x64
 Size:             512MB
 Backups Active:   false
       eos
@@ -75,7 +98,7 @@ Status:           \e[32mactive\e[0m
 IP4:              104.131.186.241
 IP6:              2604:A880:0800:0010:0000:0000:031D:2001
 Region:           New York 3 - nyc3
-Image:            6918990 - 14.04 x64
+Image:            6918990 - ubuntu-14-04-x64
 Size:             512MB
 Backups Active:   false
       eos
@@ -108,7 +131,7 @@ Status:           \e[32mactive\e[0m
 IP4:              104.131.186.241
 IP6:              2604:A880:0800:0010:0000:0000:031D:2001
 Region:           New York 3 - nyc3
-Image:            6918990 - 14.04 x64
+Image:            6918990 - ubuntu-14-04-x64
 Size:             512MB
 Backups Active:   false
       eos
@@ -131,7 +154,7 @@ status active
 ip4 104.131.186.241
 ip6 2604:A880:0800:0010:0000:0000:031D:2001
 region nyc3
-Image 6918990
+image 6918990
 size 512mb
 backups_active false
       eos
@@ -156,7 +179,7 @@ status active
 ip4 104.131.186.241
 ip6 2604:A880:0800:0010:0000:0000:031D:2001
 region nyc3
-Image 6918990
+image 6918990
 size 512mb
 backups_active false
       eos
@@ -212,7 +235,7 @@ Provide one of the following:
     ip6
     private_ip
     region
-    Image
+    image
     size
     backups_active
       eos

--- a/spec/fixtures/show_droplet_user_image.json
+++ b/spec/fixtures/show_droplet_user_image.json
@@ -1,0 +1,82 @@
+{
+  "droplet": {
+    "id": 6918990,
+    "name": "example.com",
+    "memory": 512,
+    "vcpus": 1,
+    "disk": 20,
+    "locked": false,
+    "status": "active",
+    "kernel": {
+      "id": 2233,
+      "name": "Ubuntu 14.04 x64 vmlinuz-3.13.0-37-generic",
+      "version": "3.13.0-37-generic"
+    },
+    "created_at": "2014-11-14T16:36:31Z",
+    "features": [
+      "ipv6",
+      "virtio"
+    ],
+    "backup_ids": [
+
+    ],
+    "snapshot_ids": [
+
+    ],
+    "image": {
+      "id": 36646276,
+      "name": "Super Cool Custom Image",
+      "distribution": "CentOS",
+      "slug": null,
+      "public": false,
+      "regions": [
+          "lon1"
+      ],
+      "created_at": "2015-02-27T14:44:25Z",
+      "min_disk_size": 20,
+      "type": "snapshot"
+    },
+    "size_slug": "512mb",
+    "networks": {
+      "v4": [
+        {
+          "ip_address": "104.131.186.241",
+          "netmask": "255.255.240.0",
+          "gateway": "104.131.176.1",
+          "type": "public"
+        }
+      ],
+      "v6": [
+        {
+          "ip_address": "2604:A880:0800:0010:0000:0000:031D:2001",
+          "netmask": 64,
+          "gateway": "2604:A880:0800:0010:0000:0000:0000:0001",
+          "type": "public"
+        }
+      ]
+    },
+    "region": {
+      "name": "New York 3",
+      "slug": "nyc3",
+      "sizes": [
+        "32gb",
+        "16gb",
+        "2gb",
+        "1gb",
+        "4gb",
+        "8gb",
+        "512mb",
+        "64gb",
+        "48gb"
+      ],
+      "features": [
+        "virtio",
+        "private_networking",
+        "backups",
+        "ipv6",
+        "metadata"
+      ],
+      "available": true
+    }
+  }
+}


### PR DESCRIPTION
Gives better information on image for droplet:

* Slugs convey more information about an image than a name for non-user images:
	`ubuntu-14-04-64` vs `14.04 x64`
* User images have no slug
* Add some logic to handle both
* Update README with changes