### PR TITLE
Add Min Disk Size to info_image

### DIFF
--- a/lib/tugboat/middleware/info_image.rb
+++ b/lib/tugboat/middleware/info_image.rb
@@ -17,6 +17,7 @@ module Tugboat
         say "Name:             #{image.name}"
         say "ID:               #{image.id}"
         say "Distribution:     #{image.distribution}"
+        say "Min Disk Size:    #{image.min_disk_size}GB"
 
         @app.call(env)
       end

--- a/spec/cli/info_image_cli_spec.rb
+++ b/spec/cli/info_image_cli_spec.rb
@@ -21,6 +21,7 @@ Image fuzzy name provided. Finding image ID...done\e[0m, 12789325 (745.1.0 (alph
 Name:             745.1.0 (alpha)
 ID:               12789325
 Distribution:     CoreOS
+Min Disk Size:    20GB
       eos
     end
 
@@ -42,6 +43,7 @@ Image id provided. Finding Image...done\e[0m, 12438838 (Redmine on 14.04)
 Name:             Redmine on 14.04
 ID:               12438838
 Distribution:     Ubuntu
+Min Disk Size:    20GB
       eos
     end
 
@@ -63,6 +65,7 @@ Image name provided. Finding Image...done\e[0m, 12438838 (Redmine on 14.04)
 Name:             Redmine on 14.04
 ID:               12438838
 Distribution:     Ubuntu
+Min Disk Size:    20GB
       eos
     end
 
@@ -139,6 +142,7 @@ Please choose a image: ["0", "1", "2", "3", "4", "5", "6", "7"]\x20
 Name:             14.10 x32
 ID:               9801951
 Distribution:     Ubuntu
+Min Disk Size:    20GB
       eos
     end
 


### PR DESCRIPTION
Now that tugboat supports API 2.0 (thanks!), reporting additional image info can help scripts use tugboat to automate creation of images from snapshots.

FYI – I'm not a Ruby programmer, so apologies if I've missed something. I did ensure `bundle exec rspec` tests are all passing, so hopefully this simple feature suggestion will be acceptable & easy to merge.