### PR TITLE
Changes logic when no ssh_key_path has been set

### DIFF
--- a/lib/tugboat/middleware/ssh_droplet.rb
+++ b/lib/tugboat/middleware/ssh_droplet.rb
@@ -5,11 +5,17 @@ module Tugboat
         say "Executing SSH on Droplet #{env["droplet_name"]}..."
 
         options = [
-          "-o", "IdentitiesOnly=yes",
           "-o", "LogLevel=ERROR",
           "-o", "StrictHostKeyChecking=no",
           "-o", "UserKnownHostsFile=/dev/null",
-          "-i", File.expand_path(env["config"].ssh_key_path.to_s)]
+        ]
+
+        if env["config"].ssh_key_path.nil? || env["config"].ssh_key_path.empty?
+          options.push("-o", "IdentitiesOnly=no")
+        else
+          options.push("-o", "IdentitiesOnly=yes")
+          options.push("-i", File.expand_path(env["config"].ssh_key_path.to_s))
+        end
 
         if env["user_droplet_ssh_port"]
           options.push("-p", env["user_droplet_ssh_port"].to_s)
@@ -51,6 +57,8 @@ module Tugboat
         if env["user_droplet_ssh_command"]
           options.push(env["user_droplet_ssh_command"])
         end
+
+        say "SShing with options: #{options.join(" ")}"
 
         Kernel.exec("ssh", *options)
 

--- a/spec/middleware/ssh_droplet_spec.rb
+++ b/spec/middleware/ssh_droplet_spec.rb
@@ -11,10 +11,10 @@ describe Tugboat::Middleware::SSHDroplet do
 
     it "exec ssh with correct options" do
       expect(Kernel).to receive(:exec).with("ssh",
-                        "-o", "IdentitiesOnly=yes",
                         "-o", "LogLevel=ERROR",
                         "-o", "StrictHostKeyChecking=no",
                         "-o", "UserKnownHostsFile=/dev/null",
+                        "-o", "IdentitiesOnly=yes",
                         "-i", File.expand_path(ssh_key_path),
                         "-p", ssh_port,
                         "#{ssh_user}@#{droplet_ip}")
@@ -25,12 +25,30 @@ describe Tugboat::Middleware::SSHDroplet do
       described_class.new(app).call(env)
     end
 
-    it "executes ssh with custom options" do
+    it "exec ssh with IdentitiesOnly=no if no ssh_key_path in config" do
       expect(Kernel).to receive(:exec).with("ssh",
-                        "-o", "IdentitiesOnly=yes",
                         "-o", "LogLevel=ERROR",
                         "-o", "StrictHostKeyChecking=no",
                         "-o", "UserKnownHostsFile=/dev/null",
+                        "-o", "IdentitiesOnly=no",
+                        "-p", ssh_port,
+                        "#{ssh_user}@#{droplet_ip}")
+
+      env["droplet_ip"] = droplet_ip
+
+      config.data['ssh']['ssh_key_path'] = nil
+
+      env["config"] = config
+
+      described_class.new(app).call(env)
+    end
+
+    it "executes ssh with custom options" do
+      expect(Kernel).to receive(:exec).with("ssh",
+                        "-o", "LogLevel=ERROR",
+                        "-o", "StrictHostKeyChecking=no",
+                        "-o", "UserKnownHostsFile=/dev/null",
+                        "-o", "IdentitiesOnly=yes",
                         "-i", File.expand_path(ssh_key_path),
                         "-p", ssh_port,
                         "-e",
@@ -51,10 +69,10 @@ describe Tugboat::Middleware::SSHDroplet do
 
     it "executes ssh with private IP if option chosen" do
       expect(Kernel).to receive(:exec).with("ssh",
-                        "-o", "IdentitiesOnly=yes",
                         "-o", "LogLevel=ERROR",
                         "-o", "StrictHostKeyChecking=no",
                         "-o", "UserKnownHostsFile=/dev/null",
+                        "-o", "IdentitiesOnly=yes",
                         "-i", File.expand_path(ssh_key_path),
                         "-p", ssh_port,
                         "-e",


### PR DESCRIPTION
```
 IdentitiesOnly
             Specifies that ssh(1) should only use the authentication identity
             files configured in the ssh_config files, even if ssh-agent(1) or
             a PKCS11Provider offers more identities.  The argument to this
             keyword must be “yes” or “no”.  This option is intended for situ‐
             ations where ssh-agent offers many different identities.  The
             default is “no”.
```

So when we have an ssh that is not in a path (such as using an ssh key located on a smart card), you can still ssh to it! :+1:

Also updates specs for this change

Closes #160