### PR TITLE
Fix showing of private ips when running 'tugboat droplets'

### DIFF
--- a/lib/tugboat/middleware/list_droplets.rb
+++ b/lib/tugboat/middleware/list_droplets.rb
@@ -13,8 +13,8 @@ module Tugboat
         droplet_list.each do |droplet|
           has_one = true
 
-          if droplet.private_ip_address
-            private_addr = droplet.networks.v4.detect { |address| address.type == 'private' }
+          private_addr = droplet.networks.v4.detect { |address| address.type == 'private' }
+          if private_addr
             private_ip = ", privateip: #{private_addr.ip_address}"
           end
 


### PR DESCRIPTION
The issue is that private ip's do not show up when you run 'tugboat droplets'. This is due to the change in datastructure in the ipv6 address migration.

This should fix issue https://github.com/pearkes/tugboat/issues/220