### PR TITLE
Refactor the response.success? into helper

### DIFF
--- a/lib/tugboat/middleware/base.rb
+++ b/lib/tugboat/middleware/base.rb
@@ -18,6 +18,13 @@ module Tugboat
         say "", :clear, false
       end
 
+      def check_response_success(task_string, response)
+        unless response.success?
+          say "Failed to #{task_string}: #{response.message}", :red
+          exit 1
+        end
+      end
+
       def call(env)
         @app.call(env)
       end

--- a/lib/tugboat/middleware/info_droplet.rb
+++ b/lib/tugboat/middleware/info_droplet.rb
@@ -6,10 +6,7 @@ module Tugboat
 
         response = ocean.droplet.show env["droplet_id"]
 
-        unless response.success?
-          say "Failed to get info for Droplet: #{response.message}", :red
-          exit 1
-        end
+        check_response_success('get info for Droplet', response)
 
         droplet = response.droplet
 


### PR DESCRIPTION
I'm trying out recording my coding sessions: https://vimeo.com/147890569

Otherwise, just a simple refactor, will extend it out to the rest of the methods when I figure out how to unit test the helper method