### PR TITLE
Add Bundler.require(:development) for default rake tasks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,8 @@ You can then execute tugboat:
 As well as run the tests:
 
     $ bundle exec rspec
+Or
+	$ rake spec
 
 To install the gem on your system from source:
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,6 @@
+require 'bundler'
+Bundler.require(:development)
+
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'cucumber/rake/task'


### PR DESCRIPTION
[Minor issue]

No more need to execute `bundle exec` as bundler will be already
loaded it.

Also fix the following error if someone tried to call `rake spec` directly, because code would exec that you'd call 'bundle exec'.

```
➜  tugboat git:(master) ✗ rake spec
rake aborted!
LoadError: cannot load such file -- cucumber/rake/task
/Users/andrehjr/work/tugboat/Rakefile:6:in `<top (required)>'
```