### PR TITLE
Configuration support for IPv6

### DIFF
--- a/lib/tugboat/config.rb
+++ b/lib/tugboat/config.rb
@@ -106,7 +106,7 @@ module Tugboat
     end
 
     # Writes a config file
-    def create_config_file(access_token, ssh_key_path, ssh_user, ssh_port, region, image, size, ssh_key, private_networking, backups_enabled)
+    def create_config_file(access_token, ssh_key_path, ssh_user, ssh_port, region, image, size, ssh_key, private_networking, backups_enabled, ip6)
       # Default SSH Key path
       if ssh_key_path.empty?
         ssh_key_path = File.join("~", DEFAULT_SSH_KEY_PATH)
@@ -144,6 +144,10 @@ module Tugboat
         backups_enabled = DEFAULT_BACKUPS_ENABLED
       end
 
+      if ip6.empty?
+        ip6 = DEFAULT_IP6
+      end
+
       require 'yaml'
       File.open(@path, File::RDWR|File::TRUNC|File::CREAT, 0600) do |file|
         data = {
@@ -160,7 +164,8 @@ module Tugboat
                   "size" => size,
                   "ssh_key" => ssh_key,
                   "private_networking" => private_networking,
-                  "backups_enabled" => backups_enabled
+                  "backups_enabled" => backups_enabled,
+                  "ip6" => ip6,
                 }
         }
         file.write data.to_yaml

--- a/lib/tugboat/middleware/ask_for_credentials.rb
+++ b/lib/tugboat/middleware/ask_for_credentials.rb
@@ -20,9 +20,10 @@ module Tugboat
         ssh_key  = ask "Enter your default ssh key IDs (optional, defaults to none, comma separated string):"
         private_networking = ask "Enter your default for private networking (optional, defaults to false):"
         backups_enabled = ask "Enter your default for enabling backups (optional, defaults to false):"
+        ip6      = ask "Enter your default for IPv6 (optional, defaults to false):"
 
         # Write the config file.
-        env['config'].create_config_file(access_token, ssh_key_path, ssh_user, ssh_port, region, image, size, ssh_key, private_networking, backups_enabled)
+        env['config'].create_config_file(access_token, ssh_key_path, ssh_user, ssh_port, region, image, size, ssh_key, private_networking, backups_enabled, ip6)
         env['config'].reload!
 
         @app.call(env)

--- a/spec/cli/authorize_cli_spec.rb
+++ b/spec/cli/authorize_cli_spec.rb
@@ -36,6 +36,8 @@ describe Tugboat::CLI do
       expect($stdin).to receive(:gets).and_return(private_networking)
       expect($stdout).to receive(:print).with("Enter your default for enabling backups (optional, defaults to false): ")
       expect($stdin).to receive(:gets).and_return(backups_enabled)
+      expect($stdout).to receive(:print).with("Enter your default for IPv6 (optional, defaults to false): ")
+      expect($stdin).to receive(:gets).and_return(ip6)
 
       @cli.authorize
 
@@ -54,6 +56,7 @@ describe Tugboat::CLI do
       expect(config["defaults"]["ssh_key"]).to eq ssh_key_id
       expect(config["defaults"]["private_networking"]).to eq private_networking
       expect(config["defaults"]["backups_enabled"]).to eq backups_enabled
+      expect(config["defaults"]["ip6"]).to eq ip6
     end
 
     it "sets defaults if no input given" do
@@ -81,6 +84,8 @@ describe Tugboat::CLI do
       expect($stdout).to receive(:print).with("Enter your default for private networking (optional, defaults to false): ")
       expect($stdin).to receive(:gets).and_return('')
       expect($stdout).to receive(:print).with("Enter your default for enabling backups (optional, defaults to false): ")
+      expect($stdin).to receive(:gets).and_return('')
+      expect($stdout).to receive(:print).with("Enter your default for IPv6 (optional, defaults to true): ")
       expect($stdin).to receive(:gets).and_return('')
 
       @cli.authorize

--- a/spec/cli/config_cli_spec.rb
+++ b/spec/cli/config_cli_spec.rb
@@ -25,6 +25,7 @@ defaults:
   ssh_key: '1234'
   private_networking: 'false'
   backups_enabled: 'false'
+  ip6: 'false'
       eos
     end
 
@@ -50,6 +51,7 @@ defaults:
   ssh_key: '1234'
   private_networking: 'false'
   backups_enabled: 'false'
+  ip6: 'true'
       eos
     end
   end

--- a/spec/cli/create_cli_spec.rb
+++ b/spec/cli/create_cli_spec.rb
@@ -6,7 +6,7 @@ describe Tugboat::CLI do
   describe "create a droplet" do
     it "with a name, uses defaults from configuration" do
       stub_request(:post, "https://api.digitalocean.com/v2/droplets").
-         with(:body => "{\"name\":\"foo\",\"size\":\"512mb\",\"image\":\"ubuntu-14-04-x64\",\"region\":\"nyc2\",\"ssh_keys\":[\"1234\"],\"private_networking\":\"false\",\"backups_enabled\":\"false\",\"ipv6\":null,\"user_data\":null}",
+         with(:body => "{\"name\":\"foo\",\"size\":\"512mb\",\"image\":\"ubuntu-14-04-x64\",\"region\":\"nyc2\",\"ssh_keys\":[\"1234\"],\"private_networking\":\"false\",\"backups_enabled\":\"false\",\"ipv6\":\"true\",\"user_data\":null}",
               :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
          to_return(:status => 200, :body => fixture('create_droplet'), :headers => {})
 
@@ -19,7 +19,7 @@ Queueing creation of droplet '#{droplet_name}'...Droplet created!
 
     it "with args does not use defaults from configuration" do
       stub_request(:post, "https://api.digitalocean.com/v2/droplets").
-         with(:body => "{\"name\":\"example.com\",\"size\":\"1gb\",\"image\":\"ubuntu-12-04-x64\",\"region\":\"nyc3\",\"ssh_keys\":[\"foo_bar_key\"],\"private_networking\":\"false\",\"backups_enabled\":\"false\",\"ipv6\":null,\"user_data\":null}",
+         with(:body => "{\"name\":\"example.com\",\"size\":\"1gb\",\"image\":\"ubuntu-12-04-x64\",\"region\":\"nyc3\",\"ssh_keys\":[\"foo_bar_key\"],\"private_networking\":\"false\",\"backups_enabled\":\"false\",\"ipv6\":\"true\",\"user_data\":null}",
               :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
          to_return(:status => 200, :body => fixture('create_droplet'), :headers => {})
 
@@ -49,7 +49,7 @@ Queueing creation of droplet 'example.com'...Droplet created!
 
     it "with user data args" do
       stub_request(:post, "https://api.digitalocean.com/v2/droplets").
-         with(:body => "{\"name\":\"example.com\",\"size\":\"512mb\",\"image\":\"ubuntu-14-04-x64\",\"region\":\"nyc2\",\"ssh_keys\":[\"1234\"],\"private_networking\":\"false\",\"backups_enabled\":\"false\",\"ipv6\":null,\"user_data\":\"#!/bin/bash\\n\\necho \\\"Hello world\\\"\"}",
+         with(:body => "{\"name\":\"example.com\",\"size\":\"512mb\",\"image\":\"ubuntu-14-04-x64\",\"region\":\"nyc2\",\"ssh_keys\":[\"1234\"],\"private_networking\":\"false\",\"backups_enabled\":\"false\",\"ipv6\":\"true\",\"user_data\":\"#!/bin/bash\\n\\necho \\\"Hello world\\\"\"}",
               :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
          to_return(:status => 200, :body => fixture('create_droplet'), :headers => {})
 
@@ -103,7 +103,7 @@ eos
 
     it "does not clobber named droplets that contain the word help" do
       stub_request(:post, "https://api.digitalocean.com/v2/droplets").
-         with(:body => "{\"name\":\"somethingblahblah--help\",\"size\":\"512mb\",\"image\":\"ubuntu-14-04-x64\",\"region\":\"nyc2\",\"ssh_keys\":[\"1234\"],\"private_networking\":\"false\",\"backups_enabled\":\"false\",\"ipv6\":null,\"user_data\":null}",
+         with(:body => "{\"name\":\"somethingblahblah--help\",\"size\":\"512mb\",\"image\":\"ubuntu-14-04-x64\",\"region\":\"nyc2\",\"ssh_keys\":[\"1234\"],\"private_networking\":\"false\",\"backups_enabled\":\"false\",\"ipv6\":\"true\",\"user_data\":null}",
               :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
          to_return(:status => 200, :body => fixture('create_droplet'), :headers => {})
 

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -33,12 +33,13 @@ describe Tugboat::Configuration do
     let(:ssh_key_id)         { '1234' }
     let(:private_networking) { 'false' }
     let(:backups_enabled)    { 'false' }
+    let(:ip6)                { 'false' }
 
     let(:config)           { config = Tugboat::Configuration.instance }
 
     before :each do
       # Create a temporary file
-      config.create_config_file(access_token, ssh_key_path, ssh_user, ssh_port, region, image, size, ssh_key_id, private_networking, backups_enabled)
+      config.create_config_file(access_token, ssh_key_path, ssh_user, ssh_port, region, image, size, ssh_key_id, private_networking, backups_enabled, ip6)
     end
 
     it "can be created" do
@@ -105,6 +106,7 @@ describe Tugboat::Configuration do
     let(:config_default_ssh_key)    { Tugboat::Configuration::DEFAULT_SSH_KEY }
     let(:config_default_networking) { Tugboat::Configuration::DEFAULT_PRIVATE_NETWORKING }
     let(:config_default_backups)    { Tugboat::Configuration::DEFAULT_BACKUPS_ENABLED }
+    let(:config_default_ip6)    	{ Tugboat::Configuration::DEFAULT_IP6 }
     let(:backwards_config) {
       {
                 'authentication' => { 'client_key' => client_key, 'api_key' => api_key },
@@ -149,6 +151,11 @@ describe Tugboat::Configuration do
     it "should use default backups_enabled if not in the configuration" do
       backups_enabled = config.default_backups_enabled
       expect(backups_enabled).to eql config_default_backups
+    end
+
+    it "should use default ip6 if not in the configuration" do
+      ip6 = config.default_ip6
+      expect(ip6).to eql config_default_ip6
     end
 
   end

--- a/spec/shared/environment.rb
+++ b/spec/shared/environment.rb
@@ -19,6 +19,7 @@ shared_context "spec" do
   let(:ssh_public_key)     { 'ssh-dss A123= user@host' }
   let(:private_networking) { 'false'}
   let(:backups_enabled)    { 'false'}
+  let(:ip6)                { 'false' }
   let(:ocean)              { Barge::Client.new(:access_token => access_token) }
   let(:app)                { lambda { |env| } }
   let(:env)                { {} }
@@ -30,7 +31,7 @@ shared_context "spec" do
     @cli = Tugboat::CLI.new
 
     # Set a temprary project path and create fake config.
-    config.create_config_file(access_token, ssh_key_path, ssh_user, ssh_port, region, image, size, ssh_key_id, private_networking, backups_enabled)
+    config.create_config_file(access_token, ssh_key_path, ssh_user, ssh_port, region, image, size, ssh_key_id, private_networking, backups_enabled, ip6)
     config.reload!
 
     # Keep track of the old stderr / out


### PR DESCRIPTION
The commit that introduced creating IPv6 enabled instances was missing configuration file support. The default is deliberately changed to "enabled", because IMHO we should actively encourage deployment of IPv6.