### PR TITLE
Install dependencies locally when developing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@
 To add a feature, fix a bug, or to run a development build of Tugboat
 on your machine, clone down the repo and run:
 
-    $ bundle
+    $ bundle install --path vendor/bundle
 
 You can then execute tugboat:
 


### PR DESCRIPTION
I think it makes more sense to install dependencies locally instead of systemd-wide for local development. This simplifies testing new upstream versions.