### PR TITLE
Add Regions to info_image

### DIFF
--- a/lib/tugboat/middleware/info_image.rb
+++ b/lib/tugboat/middleware/info_image.rb
@@ -18,6 +18,7 @@ module Tugboat
         say "ID:               #{image.id}"
         say "Distribution:     #{image.distribution}"
         say "Min Disk Size:    #{image.min_disk_size}GB"
+        say "Regions:          #{image.regions.join(',')}"
 
         @app.call(env)
       end

--- a/spec/cli/info_image_cli_spec.rb
+++ b/spec/cli/info_image_cli_spec.rb
@@ -22,6 +22,7 @@ Name:             745.1.0 (alpha)
 ID:               12789325
 Distribution:     CoreOS
 Min Disk Size:    20GB
+Regions:          nyc1,sfo1,nyc2,ams2,sgp1,lon1,nyc3,ams3,fra1
       eos
     end
 
@@ -44,6 +45,7 @@ Name:             Redmine on 14.04
 ID:               12438838
 Distribution:     Ubuntu
 Min Disk Size:    20GB
+Regions:          nyc1,ams1,sfo1,nyc2,ams2,sgp1,lon1,nyc3,ams3,fra1
       eos
     end
 
@@ -66,6 +68,7 @@ Name:             Redmine on 14.04
 ID:               12438838
 Distribution:     Ubuntu
 Min Disk Size:    20GB
+Regions:          nyc1,ams1,sfo1,nyc2,ams2,sgp1,lon1,nyc3,ams3,fra1
       eos
     end
 
@@ -143,6 +146,7 @@ Name:             14.10 x32
 ID:               9801951
 Distribution:     Ubuntu
 Min Disk Size:    20GB
+Regions:          nyc1,ams1,sfo1,nyc2,ams2,sgp1,lon1,nyc3,ams3,fra1
       eos
     end
 


### PR DESCRIPTION
Now that tugboat supports API 2.0 (thanks!), reporting additional image info can help scripts use tugboat to automate creation of images from snapshots. We added [Min Disk Size](https://github.com/pearkes/tugboat/pull/193) last October. Now, I'm proposing we add Regions too, since a valid region must be known to successfully build a droplet from an snapshot.

Regions are reported in a comma-separated list:

    Name:             Redmine on 14.04
    ID:               12438838
    Distribution:     Ubuntu
    Min Disk Size:    20GB
    Regions:          nyc1,ams1,sfo1,nyc2,ams2,sgp1,lon1,nyc3,ams3,fra1

I considered sorting the list, but decided against it, since, while I couldn't find documentation of the significance of the ordering of regions returned by the API, the sequence mirrors the sequence on the website for creating droplets, suggesting the regions may be in order of preference.

FYI – I'm not a Ruby programmer, so apologies if I've missed something. I did ensure `bundle exec rspec` tests are all passing, so hopefully this simple feature suggestion will be acceptable & easy to merge.