### PR TITLE
Fixes library pinning issues in `.gemspec`

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ D, [2015-12-06T12:04:27.149334 #92772] DEBUG -- : Request Headers:
 ----------------
 Authorization : Bearer [TOKEN REDACTED]
 Content-Type  : application/json
-User-Agent    : Faraday v0.9.2
+User-Agent    : Faraday v0.11.0
 
 Request Body:
 -------------

--- a/features/cassettes/config/Array_of_SSH_Keys_in_Config.yml
+++ b/features/cassettes/config/Array_of_SSH_Keys_in_Config.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v0.9.2
+      - Faraday v0.11.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:

--- a/features/cassettes/config/Single_SSH_key_as_number_in_config.yml
+++ b/features/cassettes/config/Single_SSH_key_as_number_in_config.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - Faraday v0.9.2
+      - Faraday v0.11.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:

--- a/spec/cli/authorize_cli_spec.rb
+++ b/spec/cli/authorize_cli_spec.rb
@@ -12,7 +12,7 @@ describe Tugboat::CLI do
 
     it "asks the right questions and checks credentials" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       expect($stdout).to receive(:print).exactly(6).times
@@ -61,7 +61,7 @@ describe Tugboat::CLI do
 
     it "sets defaults if no input given" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>/Bearer/, 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>/Bearer/, 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       expect($stdout).to receive(:print).exactly(6).times

--- a/spec/cli/create_cli_spec.rb
+++ b/spec/cli/create_cli_spec.rb
@@ -7,7 +7,7 @@ describe Tugboat::CLI do
     it "with a name, uses defaults from configuration" do
       stub_request(:post, "https://api.digitalocean.com/v2/droplets").
          with(:body => "{\"name\":\"foo\",\"size\":\"512mb\",\"image\":\"ubuntu-14-04-x64\",\"region\":\"nyc2\",\"ssh_keys\":[\"1234\"],\"private_networking\":\"false\",\"backups_enabled\":\"false\",\"ipv6\":\"false\",\"user_data\":null}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('create_droplet'), :headers => {})
 
       @cli.create(droplet_name)
@@ -20,7 +20,7 @@ Queueing creation of droplet '#{droplet_name}'...Droplet created!
     it "with args does not use defaults from configuration" do
       stub_request(:post, "https://api.digitalocean.com/v2/droplets").
          with(:body => "{\"name\":\"example.com\",\"size\":\"1gb\",\"image\":\"ubuntu-12-04-x64\",\"region\":\"nyc3\",\"ssh_keys\":[\"foo_bar_key\"],\"private_networking\":\"false\",\"backups_enabled\":\"false\",\"ipv6\":\"false\",\"user_data\":null}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('create_droplet'), :headers => {})
 
       @cli.options = @cli.options.merge(:image => 'ubuntu-12-04-x64', :size => '1gb', :region => 'nyc3', :keys => 'foo_bar_key')
@@ -35,7 +35,7 @@ Queueing creation of droplet 'example.com'...Droplet created!
     it "with ip6 enable args" do
       stub_request(:post, "https://api.digitalocean.com/v2/droplets").
          with(:body => "{\"name\":\"example.com\",\"size\":\"512mb\",\"image\":\"ubuntu-14-04-x64\",\"region\":\"nyc2\",\"ssh_keys\":[\"1234\"],\"private_networking\":\"false\",\"backups_enabled\":\"false\",\"ipv6\":\"true\",\"user_data\":null}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('create_droplet'), :headers => {})
 
       @cli.options = @cli.options.merge(:ip6 => 'true')
@@ -50,7 +50,7 @@ Queueing creation of droplet 'example.com'...Droplet created!
     it "with user data args" do
       stub_request(:post, "https://api.digitalocean.com/v2/droplets").
          with(:body => "{\"name\":\"example.com\",\"size\":\"512mb\",\"image\":\"ubuntu-14-04-x64\",\"region\":\"nyc2\",\"ssh_keys\":[\"1234\"],\"private_networking\":\"false\",\"backups_enabled\":\"false\",\"ipv6\":\"false\",\"user_data\":\"#!/bin/bash\\n\\necho \\\"Hello world\\\"\"}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('create_droplet'), :headers => {})
 
       @cli.options = @cli.options.merge(:user_data => project_path + "/spec/fixtures/user_data.sh")
@@ -104,7 +104,7 @@ eos
     it "does not clobber named droplets that contain the word help" do
       stub_request(:post, "https://api.digitalocean.com/v2/droplets").
          with(:body => "{\"name\":\"somethingblahblah--help\",\"size\":\"512mb\",\"image\":\"ubuntu-14-04-x64\",\"region\":\"nyc2\",\"ssh_keys\":[\"1234\"],\"private_networking\":\"false\",\"backups_enabled\":\"false\",\"ipv6\":\"false\",\"user_data\":null}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('create_droplet'), :headers => {})
 
       @cli.create('somethingblahblah--help')

--- a/spec/cli/debug_cli_spec.rb
+++ b/spec/cli/debug_cli_spec.rb
@@ -13,11 +13,11 @@ describe Tugboat::CLI do
 
     it "gives full faraday logs" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-        with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+        with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
         to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-        with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+        with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
         to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       @cli.droplets
@@ -39,11 +39,11 @@ describe Tugboat::CLI do
 
     it "gives full faraday logs with redacted API keys" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-        with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+        with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
         to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
       @cli.droplets
 

--- a/spec/cli/destroy_cli_spec.rb
+++ b/spec/cli/destroy_cli_spec.rb
@@ -6,15 +6,15 @@ describe Tugboat::CLI do
   describe "destroy" do
     it "destroys a droplet with a fuzzy name" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:delete, "https://api.digitalocean.com/v2/droplets/6918990").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 204, :body => "", :headers => {})
 
       expect($stdin).to receive(:gets).and_return("y")
@@ -28,11 +28,11 @@ eos
 
     it "destroys a droplet with an id" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets/6918990?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplet'), :headers => {})
 
       stub_request(:delete, "https://api.digitalocean.com/v2/droplets/6918990").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 204, :body => "", :headers => {})
 
       expect($stdin).to receive(:gets).and_return("y")
@@ -48,15 +48,15 @@ Droplet id provided. Finding Droplet...done\e[0m, 6918990 (example.com)\nWarning
 
     it "destroys a droplet with a name" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-      with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+      with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
       to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:delete, "https://api.digitalocean.com/v2/droplets/6918990").
-      with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+      with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
       to_return(:status => 204, :body => "", :headers => {})
 
       expect($stdin).to receive(:gets).and_return("y")
@@ -71,15 +71,15 @@ Droplet name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)\nWa
 
     it "destroys a droplet with confirm flag set" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-        with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+        with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
         to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:delete, "https://api.digitalocean.com/v2/droplets/6918990").
-        with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+        with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
         to_return(:status => 204, :body => "", :headers => {})
 
       @cli.options = @cli.options.merge(:name => 'example.com', :confirm => true)
@@ -93,11 +93,11 @@ Queuing destroy for 6918990 (example.com)...Deletion Successful!
 
     it "does not destroy a droplet if no is chosen" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-        with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+        with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
         to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-        with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+        with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
         to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       $stdin.should_receive(:gets).and_return("n")

--- a/spec/cli/destroy_image_cli_spec.rb
+++ b/spec/cli/destroy_image_cli_spec.rb
@@ -6,11 +6,11 @@ describe Tugboat::CLI do
   describe "destroy image" do
     it "destroys an image with a fuzzy name" do
       stub_request(:get, "https://api.digitalocean.com/v2/images?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_images_global'), :headers => {})
 
       stub_request(:delete, "https://api.digitalocean.com/v2/images/6376601").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 204, :body => "", :headers => {})
 
       expect($stdin).to receive(:gets).and_return("y")
@@ -24,11 +24,11 @@ Image fuzzy name provided. Finding image ID...done\e[0m, 6376601 (My application
 
     it "destroys an image with an id" do
       stub_request(:get, "https://api.digitalocean.com/v2/images/6376601?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_image'), :headers => {})
 
       stub_request(:delete, "https://api.digitalocean.com/v2/images/6376601").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 204, :body => "", :headers => {})
 
       expect($stdin).to receive(:gets).and_return("y")
@@ -44,11 +44,11 @@ Image id provided. Finding Image...done\e[0m, 6376601 (My application image)\nWa
 
     it "destroys an image with a name" do
       stub_request(:get, "https://api.digitalocean.com/v2/images?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_images_global'), :headers => {})
 
       stub_request(:delete, "https://api.digitalocean.com/v2/images/6376601").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 204, :body => "", :headers => {})
 
       expect($stdin).to receive(:gets).and_return("y")
@@ -62,11 +62,11 @@ Image id provided. Finding Image...done\e[0m, 6376601 (My application image)\nWa
 
     it "destroys an image with confirm flag set" do
             stub_request(:get, "https://api.digitalocean.com/v2/images?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_images_global'), :headers => {})
 
       stub_request(:delete, "https://api.digitalocean.com/v2/images/6376601").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 204, :body => "", :headers => {})
 
       @cli.options = @cli.options.merge(:name => "My application image")

--- a/spec/cli/droplets_cli_spec.rb
+++ b/spec/cli/droplets_cli_spec.rb
@@ -6,11 +6,11 @@ describe Tugboat::CLI do
   describe "droplets" do
     it "shows a list when droplets exist" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture("show_droplets"), :headers => {'Content-Type' => 'application/json'},)
 
       @cli.droplets
@@ -26,11 +26,11 @@ example3.com (ip: 104.236.32.173, status: \e[31moff\e[0m, region: nyc3, id: 3164
 
     it "shows a private IP if droplet in list has private IP" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture("show_droplets_private_ip"), :headers => {'Content-Type' => 'application/json'},)
 
       @cli.droplets
@@ -46,11 +46,11 @@ example3.com (ip: 104.236.32.173, status: \e[31moff\e[0m, region: nyc3, id: 3164
 
     it "returns an error message when no droplets exist" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture("show_droplets_empty"), :headers => {'Content-Type' => 'application/json'},)
 
       @cli.droplets
@@ -65,11 +65,11 @@ Try creating one with \e[32m`tugboat create`\e[0m
 
     it "shows no output when --quiet is set" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture("show_droplets"), :headers => {'Content-Type' => 'application/json'},)
 
       @cli.options = @cli.options.merge(:quiet => true)
@@ -83,11 +83,11 @@ Try creating one with \e[32m`tugboat create`\e[0m
 
     it "includes urls when --include-urls is set" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture("show_droplets"), :headers => {'Content-Type' => 'application/json'},)
 
       @cli.options = @cli.options.merge("include_urls" => true)
@@ -104,15 +104,15 @@ example3.com (ip: 104.236.32.173, status: \e[31moff\e[0m, region: nyc3, id: 3164
 
     it "paginates when multiple pages are returned" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture("show_droplets_paginated_first"), :headers => {'Content-Type' => 'application/json'},)
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=2&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture("show_droplets_paginated_last"), :headers => {'Content-Type' => 'application/json'},)
 
       @cli.options = @cli.options.merge("include_urls" => true)

--- a/spec/cli/env_variable_spec.rb
+++ b/spec/cli/env_variable_spec.rb
@@ -6,7 +6,7 @@ describe Tugboat::CLI do
   describe "DO_API_TOKEN=foobar" do
     it "verifies with the ENV variable DO_API_TOKEN" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer env_variable', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer env_variable', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       allow(ENV).to receive(:[]).with('HOME').and_return('/tmp/fake_home')
@@ -21,7 +21,7 @@ describe Tugboat::CLI do
 
     it "does not use ENV variable DO_API_TOKEN if empty" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       allow(ENV).to receive(:[]).with('HOME').and_return('/tmp/fake_home')

--- a/spec/cli/halt_cli_spec.rb
+++ b/spec/cli/halt_cli_spec.rb
@@ -6,16 +6,16 @@ describe Tugboat::CLI do
   describe "halt" do
     it "halts a droplet with a fuzzy name" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:post, "https://api.digitalocean.com/v2/droplets/6918990/actions").
          with(:body => "{\"type\":\"shutdown\"}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('shutdown_response'), :headers => {})
 
       @cli.halt("example.com")
@@ -28,16 +28,16 @@ Queuing shutdown for 6918990 (example.com)...Halt successful!
 
     it "halts a droplet hard when the hard option is used" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:post, "https://api.digitalocean.com/v2/droplets/6918990/actions").
          with(:body => "{\"type\":\"power_off\"}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => "", :headers => {})
 
       @cli.options = @cli.options.merge(:hard => true)
@@ -51,20 +51,20 @@ Queuing hard shutdown for 6918990 (example.com)...Halt successful!
 
     it "halts a droplet with an id" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets/?per_page=200").
-        with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+        with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
         to_return(:status => 200, :body => fixture("show_droplets"), :headers => {'Content-Type' => 'application/json'},)
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets/6918990?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplet'), :headers => {})
 
       stub_request(:post, "https://api.digitalocean.com/v2/droplets/6918990/actions").
          with(:body => "{\"type\":\"shutdown\"}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('shutdown_response'), :headers => {})
 
       @cli.options = @cli.options.merge(:id => '6918990')
@@ -79,16 +79,16 @@ Queuing shutdown for 6918990 (example.com)...Halt successful!
 
     it "halts a droplet with a name" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture("show_droplets"), :headers => {'Content-Type' => 'application/json'},)
 
       stub_request(:post, "https://api.digitalocean.com/v2/droplets/6918990/actions").
          with(:body => "{\"type\":\"shutdown\"}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('shutdown_response'), :headers => {})
 
       @cli.options = @cli.options.merge(:name => 'example.com')
@@ -103,11 +103,11 @@ Queuing shutdown for 6918990 (example.com)...Halt successful!
 
     it "does not halt a droplet that is off" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture("show_droplets"), :headers => {'Content-Type' => 'application/json'},)
 
       @cli.options = @cli.options.merge(:name => 'example3.com')

--- a/spec/cli/images_cli_spec.rb
+++ b/spec/cli/images_cli_spec.rb
@@ -6,11 +6,11 @@ describe Tugboat::CLI do
   describe "images" do
     it "shows all images by default" do
       stub_request(:get, "https://api.digitalocean.com/v2/images?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_images'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/images?per_page=200&private=true").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_images_global'), :headers => {})
 
       @cli.images
@@ -75,11 +75,11 @@ Redmine on 14.04 (slug: redmine, id: 12438838, distro: Ubuntu)
 
     it "acknowledges when personal images are empty when showing default full list" do
       stub_request(:get, "https://api.digitalocean.com/v2/images?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_images'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/images?per_page=200&private=true").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_images_empty'), :headers => {})
 
       @cli.options = @cli.options.merge(:show_private_images => true)
@@ -145,11 +145,11 @@ Redmine on 14.04 (slug: redmine, id: 12438838, distro: Ubuntu)
 
     it "acknowledges when personal images are empty when just show private images flag given" do
       stub_request(:get, "https://api.digitalocean.com/v2/images?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_images'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/images?per_page=200&private=true").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_images_empty'), :headers => {})
 
       @cli.options = @cli.options.merge(:show_just_private_images => true)

--- a/spec/cli/info_cli_spec.rb
+++ b/spec/cli/info_cli_spec.rb
@@ -6,11 +6,11 @@ describe Tugboat::CLI do
   describe "info" do
     it "shows an error if response is not successful" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets/6918990?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 404, :body => fixture('not_found'), :headers => {})
 
       @cli.options = @cli.options.merge(:id => 6918990)
@@ -26,15 +26,15 @@ Droplet id provided. Finding Droplet...Failed to find Droplet: The resource you 
 
     it "shows a droplet with a fuzzy name" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets/6918990?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplet'), :headers => {})
 
       @cli.info("example.com")
@@ -57,11 +57,11 @@ Backups Active:   false
 
     it "shows a droplet made from a user image" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets/6918990?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplet_user_image'), :headers => {})
 
       @cli.options = @cli.options.merge(:id => 6918990)
@@ -84,11 +84,11 @@ Backups Active:   false
 
     it "shows a droplet with an id" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets/6918990?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplet'), :headers => {})
 
       @cli.options = @cli.options.merge(:id => 6918990)
@@ -111,15 +111,15 @@ Backups Active:   false
 
     it "shows a droplet with a name" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets/6918990?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplet'), :headers => {})
 
       @cli.options = @cli.options.merge(:name => "example.com")
@@ -142,15 +142,15 @@ Backups Active:   false
 
     it "allows choice of multiple droplets" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets/6918990?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplet'), :headers => {})
 
       $stdin.should_receive(:gets).and_return('0')
@@ -181,11 +181,11 @@ Backups Active:   false
 
   it "shows a droplet with an id under porcelain mode" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets/6918990?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplet'), :headers => {})
 
       @cli.options = @cli.options.merge(:id => '6918990', :porcelain => true)
@@ -206,15 +206,15 @@ backups_active false
 
     it "shows a droplet with a name under porcelain mode" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets/6918990?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplet'), :headers => {})
 
       @cli.options = @cli.options.merge(:name => 'example.com', :porcelain => true)
@@ -235,11 +235,11 @@ backups_active false
 
   it "shows a droplet attribute with an id" do
     stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
     stub_request(:get, "https://api.digitalocean.com/v2/droplets/6918990?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplet'), :headers => {})
 
     @cli.options = @cli.options.merge(:id => '6918990', :attribute => "ip4")
@@ -253,15 +253,15 @@ Droplet id provided. Finding Droplet...done\e[0m, 6918990 (example.com)
 
   it "shows a droplet attribute with a name" do
     stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
     stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
     stub_request(:get, "https://api.digitalocean.com/v2/droplets/6918990?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplet'), :headers => {})
 
     @cli.options = @cli.options.merge(:name => 'example.com', :attribute => "ip4")
@@ -275,11 +275,11 @@ Droplet name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)
 
   it "gives error if invalid attribute given" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets/6918990?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplet'), :headers => {})
 
       @cli.options = @cli.options.merge(:id => 6918990, :porcelain => true, :attribute => "foo")
@@ -303,7 +303,7 @@ Provide one of the following:
 
   it "shows a droplet attribute with an id under porcelain mode" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets/6918990?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplet'), :headers => {})
 
       @cli.options = @cli.options.merge(:id => '6918990', :porcelain => true, :attribute => "ip4")
@@ -316,15 +316,15 @@ Provide one of the following:
 
     it "shows a droplet attribute with a name under porcelain mode" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-        with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+        with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
         to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-        with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+        with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
         to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets/6918990?per_page=200").
-        with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+        with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
         to_return(:status => 200, :body => fixture('show_droplet'), :headers => {})
 
       @cli.options = @cli.options.merge(:name => 'example.com', :porcelain => true, :attribute => "ip4")

--- a/spec/cli/info_image_cli_spec.rb
+++ b/spec/cli/info_image_cli_spec.rb
@@ -6,11 +6,11 @@ describe Tugboat::CLI do
   describe "info_image" do
     it "shows an image with a fuzzy name" do
       stub_request(:get, "https://api.digitalocean.com/v2/images?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:headers => {'Content-Type' => 'application/json'}, :status => 200, :body => fixture("show_images"))
 
       stub_request(:get, "https://api.digitalocean.com/v2/images/12789325?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:headers => {'Content-Type' => 'application/json'}, :status => 200, :body => fixture("show_coreos_image"))
 
       @cli.info_image("745.1.0 (alpha)")
@@ -28,11 +28,11 @@ Regions:          nyc1,sfo1,nyc2,ams2,sgp1,lon1,nyc3,ams3,fra1
 
     it "shows an image with an id" do
       stub_request(:get, "https://api.digitalocean.com/v2/images?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:headers => {'Content-Type' => 'application/json'}, :status => 200, :body => fixture("show_images"))
 
       stub_request(:get, "https://api.digitalocean.com/v2/images/12438838?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:headers => {'Content-Type' => 'application/json'}, :status => 200, :body => fixture("show_redmine_image"))
 
       @cli.options = @cli.options.merge(:id => 12438838)
@@ -51,11 +51,11 @@ Regions:          nyc1,ams1,sfo1,nyc2,ams2,sgp1,lon1,nyc3,ams3,fra1
 
     it "shows an image with a name" do
       stub_request(:get, "https://api.digitalocean.com/v2/images?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:headers => {'Content-Type' => 'application/json'}, :status => 200, :body => fixture("show_images"))
 
       stub_request(:get, "https://api.digitalocean.com/v2/images/12438838?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:headers => {'Content-Type' => 'application/json'}, :status => 200, :body => fixture("show_redmine_image"))
 
       @cli.options = @cli.options.merge(:name => "Redmine on 14.04")
@@ -74,11 +74,11 @@ Regions:          nyc1,ams1,sfo1,nyc2,ams2,sgp1,lon1,nyc3,ams3,fra1
 
     it "errors if no image with matching id is found" do
       stub_request(:get, "https://api.digitalocean.com/v2/images?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:headers => {'Content-Type' => 'application/json'}, :status => 200, :body => fixture("show_images"))
 
       stub_request(:get, "https://api.digitalocean.com/v2/images/123?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 404, :body => fixture('not_found'), :headers => {})
 
       @cli.options = @cli.options.merge(:id => '123')
@@ -91,7 +91,7 @@ Image id provided. Finding Image...Failed to find Image: The resource you were a
 
     it "errors if no image with matching name is found" do
       stub_request(:get, "https://api.digitalocean.com/v2/images?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:headers => {'Content-Type' => 'application/json'}, :status => 200, :body => fixture("show_images"))
 
       @cli.options = @cli.options.merge(:name => 'foobarbaz')
@@ -105,7 +105,7 @@ Unable to find an image named 'foobarbaz'.
 
     it "errors if no image with matching fuzzy name is found" do
       stub_request(:get, "https://api.digitalocean.com/v2/images?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:headers => {'Content-Type' => 'application/json'}, :status => 200, :body => fixture("show_images"))
 
       expect {@cli.info_image("foobarbaz")}.to raise_error(SystemExit)
@@ -118,11 +118,11 @@ Unable to find an image named 'foobarbaz'.
 
     it "allows choice of multiple images" do
     stub_request(:get, "https://api.digitalocean.com/v2/images?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:headers => {'Content-Type' => 'application/json'}, :status => 200, :body => fixture("show_images"))
 
     stub_request(:get, "https://api.digitalocean.com/v2/images/9801951?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('ubuntu_image_9801951'), :headers => {})
 
     $stdin.should_receive(:gets).and_return('0')

--- a/spec/cli/keys_cli_spec.rb
+++ b/spec/cli/keys_cli_spec.rb
@@ -7,7 +7,7 @@ describe Tugboat::CLI do
     it "shows a list" do
 
       stub_request(:get, "https://api.digitalocean.com/v2/account/keys?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_keys'), :headers => {})
 
       @cli.keys

--- a/spec/cli/password_reset_cli_spec.rb
+++ b/spec/cli/password_reset_cli_spec.rb
@@ -6,16 +6,16 @@ describe Tugboat::CLI do
   describe "passwordreset" do
     it "resets the root password given a fuzzy name" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture("show_droplets"), :headers => {'Content-Type' => 'application/json'},)
 
       stub_request(:post, "https://api.digitalocean.com/v2/droplets/6918990/actions").
          with(:body => "{\"type\":\"password_reset\"}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('password_reset_response'), :headers => {})
 
       @cli.password_reset("example.com")
@@ -29,20 +29,20 @@ Your new root password will be emailed to you
 
     it "resets the root password given an id" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-        with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+        with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
         to_return(:status => 200, :body => fixture("show_droplets"), :headers => {'Content-Type' => 'application/json'},)
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets/6918990?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplet'), :headers => {})
 
       stub_request(:post, "https://api.digitalocean.com/v2/droplets/6918990/actions").
          with(:body => "{\"type\":\"password_reset\"}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('password_reset_response'), :headers => {})
 
       @cli.options = @cli.options.merge(:id => 6918990)
@@ -57,16 +57,16 @@ Your new root password will be emailed to you
 
     it "resets the root password given a name" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture("show_droplets"), :headers => {'Content-Type' => 'application/json'},)
 
       stub_request(:post, "https://api.digitalocean.com/v2/droplets/6918990/actions").
          with(:body => "{\"type\":\"password_reset\"}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('password_reset_response'), :headers => {})
 
       @cli.options = @cli.options.merge(:name => "example.com")
@@ -81,16 +81,16 @@ Your new root password will be emailed to you
 
     it "raises SystemExit when a request fails" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-        with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+        with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
         to_return(:status => 200, :body => fixture("show_droplets"), :headers => {'Content-Type' => 'application/json'},)
 
       stub_request(:post, "https://api.digitalocean.com/v2/droplets/6918990/actions").
          with(:body => "{\"type\":\"password_reset\"}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
         to_return(:headers => {'Content-Type' => 'application/json'}, :status => 500, :body => '{"status":"ERROR","message":"Some error"}')
 
         @cli.options = @cli.options.merge(:name => "example.com")

--- a/spec/cli/rebuild_cli_spec.rb
+++ b/spec/cli/rebuild_cli_spec.rb
@@ -6,20 +6,20 @@ describe Tugboat::CLI do
   describe "rebuild" do
     it "rebuilds a droplet with a fuzzy name based on an image with a fuzzy name" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/images?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_images'), :headers => {})
 
       stub_request(:post, "https://api.digitalocean.com/v2/droplets/6918990/actions").
          with(:body => "{\"type\":\"rebuild\",\"image\":12790328}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => "", :headers => {})
 
       expect($stdin).to receive(:gets).and_return("y")
@@ -36,20 +36,20 @@ Warning! Potentially destructive action. Please confirm [y/n]: Queuing rebuild f
 
     it "rebuilds a droplet with an id based on an image with a fuzzy name" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets/12790328?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplet'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/images?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_images'), :headers => {})
 
       stub_request(:post, "https://api.digitalocean.com/v2/droplets/6918990/actions").
          with(:body => "{\"type\":\"rebuild\",\"image\":12790328}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => "", :headers => {})
 
       expect($stdin).to receive(:gets).and_return("y")
@@ -66,24 +66,24 @@ Warning! Potentially destructive action. Please confirm [y/n]: Queuing rebuild f
 
     it "rebuilds a droplet with a name based on an image with a fuzzy name" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets/12790328?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplet'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/images?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_images'), :headers => {})
 
       stub_request(:post, "https://api.digitalocean.com/v2/droplets/6918990/actions").
          with(:body => "{\"type\":\"rebuild\",\"image\":12790328}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => "", :headers => {})
 
       expect($stdin).to receive(:gets).and_return("y")
@@ -101,28 +101,28 @@ Warning! Potentially destructive action. Please confirm [y/n]: Queuing rebuild f
 
     it "rebuilds a droplet with a fuzzy name based on an image with an id" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets/12790328?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplet'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/images?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_images'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/images/12790328?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_image'), :headers => {})
 
       stub_request(:post, "https://api.digitalocean.com/v2/droplets/6918990/actions").
          with(:body => "{\"type\":\"rebuild\",\"image\":6376601}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => "", :headers => {})
 
       expect($stdin).to receive(:gets).and_return("y")
@@ -139,28 +139,28 @@ Warning! Potentially destructive action. Please confirm [y/n]: Queuing rebuild f
 
     it "rebuilds a droplet with an id based on an image with an id" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets/12790328?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplet'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/images?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_images'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/images/12790328?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_image'), :headers => {})
 
       stub_request(:post, "https://api.digitalocean.com/v2/droplets/6918990/actions").
          with(:body => "{\"type\":\"rebuild\",\"image\":6376601}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => "", :headers => {})
 
       expect($stdin).to receive(:gets).and_return("y")
@@ -177,28 +177,28 @@ Warning! Potentially destructive action. Please confirm [y/n]: Queuing rebuild f
 
     it "rebuilds a droplet with a name based on an image with an id" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets/12790328?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplet'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/images?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_images'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/images/12790328?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_image'), :headers => {})
 
       stub_request(:post, "https://api.digitalocean.com/v2/droplets/6918990/actions").
          with(:body => "{\"type\":\"rebuild\",\"image\":6376601}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => "", :headers => {})
 
       expect($stdin).to receive(:gets).and_return("y")
@@ -215,20 +215,20 @@ Warning! Potentially destructive action. Please confirm [y/n]: Queuing rebuild f
 
     it "rebuilds a droplet with a fuzzy name based on an image with a name" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/images?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_images'), :headers => {})
 
       stub_request(:post, "https://api.digitalocean.com/v2/droplets/6918990/actions").
          with(:body => "{\"type\":\"rebuild\",\"image\":12790328}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => "", :headers => {})
 
       expect($stdin).to receive(:gets).and_return("y")
@@ -246,24 +246,24 @@ Warning! Potentially destructive action. Please confirm [y/n]: Queuing rebuild f
 
     it "rebuilds a droplet with an id based on an image with a name" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets/12790328?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplet'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/images?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_images'), :headers => {})
 
       stub_request(:post, "https://api.digitalocean.com/v2/droplets/6918990/actions").
          with(:body => "{\"type\":\"rebuild\",\"image\":12790328}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => "", :headers => {})
 
       expect($stdin).to receive(:gets).and_return("y")
@@ -280,20 +280,20 @@ Warning! Potentially destructive action. Please confirm [y/n]: Queuing rebuild f
 
     it "rebuilds a droplet with a name based on an image with a name" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/images?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_images'), :headers => {})
 
       stub_request(:post, "https://api.digitalocean.com/v2/droplets/6918990/actions").
          with(:body => "{\"type\":\"rebuild\",\"image\":12790328}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => "", :headers => {})
 
       expect($stdin).to receive(:gets).and_return("y")
@@ -310,20 +310,20 @@ Warning! Potentially destructive action. Please confirm [y/n]: Queuing rebuild f
 
     it "rebuilds a droplet with confirm flag set" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/images?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_images'), :headers => {})
 
       stub_request(:post, "https://api.digitalocean.com/v2/droplets/6918990/actions").
          with(:body => "{\"type\":\"rebuild\",\"image\":12790328}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => "", :headers => {})
 
 

--- a/spec/cli/regions_cli_spec.rb
+++ b/spec/cli/regions_cli_spec.rb
@@ -6,7 +6,7 @@ describe Tugboat::CLI do
   describe "regions" do
     it "shows a list" do
       stub_request(:get, "https://api.digitalocean.com/v2/regions?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture("show_regions"), :headers => {'Content-Type' => 'application/json'},)
 
       @cli.regions

--- a/spec/cli/resize_cli_spec.rb
+++ b/spec/cli/resize_cli_spec.rb
@@ -6,16 +6,16 @@ describe Tugboat::CLI do
   describe "resize" do
     it "resizes a droplet with a fuzzy name" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:post, "https://api.digitalocean.com/v2/droplets/6918990/actions").
          with(:body => "{\"type\":\"resize\",\"size\":\"1gb\"}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('resize_droplet'), :headers => {})
 
       @cli.options = @cli.options.merge(:size => '1gb')
@@ -29,16 +29,16 @@ Queuing resize for 6918990 (example.com)...Resize complete!
 
     it "resizes a droplet with an id" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets/6918990?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplet'), :headers => {})
 
       stub_request(:post, "https://api.digitalocean.com/v2/droplets/6918990/actions").
          with(:body => "{\"type\":\"resize\",\"size\":\"1gb\"}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('resize_droplet'), :headers => {})
 
       @cli.options = @cli.options.merge(:size => '1gb', :id => 6918990)
@@ -52,16 +52,16 @@ Queuing resize for 6918990 (example.com)...Resize complete!
 
     it "resizes a droplet with a name" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:post, "https://api.digitalocean.com/v2/droplets/6918990/actions").
          with(:body => "{\"type\":\"resize\",\"size\":\"1gb\"}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('resize_droplet'), :headers => {})
 
       @cli.options = @cli.options.merge(:size => '1gb', :name => "example.com")
@@ -76,16 +76,16 @@ Queuing resize for 6918990 (example.com)...Resize complete!
 
     it "raises SystemExit when a request fails" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:post, "https://api.digitalocean.com/v2/droplets/6918990/actions").
          with(:body => "{\"type\":\"resize\",\"size\":\"1gb\"}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:headers => {'Content-Type' => 'application/json'}, :status => 500, :body => '{"status":"ERROR","message":"Some error"}')
 
       @cli.options = @cli.options.merge(:size => '1gb')

--- a/spec/cli/restart_cli_spec.rb
+++ b/spec/cli/restart_cli_spec.rb
@@ -6,16 +6,16 @@ describe Tugboat::CLI do
   describe "restarts a droplet" do
     it "with a fuzzy name" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:post, "https://api.digitalocean.com/v2/droplets/6918990/actions").
          with(:body => "{\"type\":\"reboot\"}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('restart_response'), :headers => {})
 
       @cli.restart("example.com")
@@ -29,16 +29,16 @@ Queuing restart for 6918990 (example.com)...Restart complete!
 
     it "restarts a droplet hard when the hard option is used" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:post, "https://api.digitalocean.com/v2/droplets/6918990/actions").
          with(:body => "{\"type\":\"power_cycle\"}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => "", :headers => {})
 
       @cli.options = @cli.options.merge(:hard => true)
@@ -52,16 +52,16 @@ Queuing hard restart for 6918990 (example.com)...Restart complete!
 
     it "with an id" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets/6918990?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplet'), :headers => {})
 
       stub_request(:post, "https://api.digitalocean.com/v2/droplets/6918990/actions").
          with(:body => "{\"type\":\"reboot\"}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('restart_response'), :headers => {})
 
       @cli.options = @cli.options.merge(:id => '6918990')
@@ -76,16 +76,16 @@ Queuing restart for 6918990 (example.com)...Restart complete!
 
     it "with a name" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:post, "https://api.digitalocean.com/v2/droplets/6918990/actions").
          with(:body => "{\"type\":\"reboot\"}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('restart_response'), :headers => {})
 
       @cli.options = @cli.options.merge(:name => 'example.com')

--- a/spec/cli/sizes_cli_spec.rb
+++ b/spec/cli/sizes_cli_spec.rb
@@ -7,7 +7,7 @@ describe Tugboat::CLI do
     it "shows a list" do
 
       stub_request(:get, "https://api.digitalocean.com/v2/sizes?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:headers => {'Content-Type' => 'application/json'}, :status => 200, :body => fixture("show_sizes"))
 
       @cli.sizes

--- a/spec/cli/snapshot_cli_spec.rb
+++ b/spec/cli/snapshot_cli_spec.rb
@@ -8,16 +8,16 @@ describe Tugboat::CLI do
   describe "snapshots a droplet" do
     it "with a fuzzy name" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-        with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+        with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
         to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:post, "https://api.digitalocean.com/v2/droplets/3164444/actions").
          with(:body => "{\"type\":\"snapshot\",\"name\":\"foo-snapshot\"}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('snapshot_response'), :headers => {})
 
       @cli.snapshot(snapshot_name, 'example3.com')
@@ -31,16 +31,16 @@ Queuing snapshot 'foo-snapshot' for 3164444 (example3.com)...Snapshot successful
 
     it "with an id" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets/3164444?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:headers => {'Content-Type' => 'application/json'}, :status => 200, :body => fixture("show_droplet_inactive"))
 
       stub_request(:post, "https://api.digitalocean.com/v2/droplets/3164494/actions").
          with(:body => "{\"type\":\"snapshot\",\"name\":\"foo-snapshot\"}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('snapshot_response'), :headers => {})
 
       @cli.options = @cli.options.merge(:id => '3164444')
@@ -56,16 +56,16 @@ Queuing snapshot 'foo-snapshot' for 3164494 (example.com)...Snapshot successful!
 
     it "with a name" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:post, "https://api.digitalocean.com/v2/droplets/3164444/actions").
          with(:body => "{\"type\":\"snapshot\",\"name\":\"foo-snapshot\"}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('snapshot_response'), :headers => {})
 
       @cli.options = @cli.options.merge(:name => 'example3.com')
@@ -80,11 +80,11 @@ Queuing snapshot 'foo-snapshot' for 3164444 (example3.com)...Snapshot successful
 
     it "does not snapshot a droplet that is active" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       @cli.options = @cli.options.merge(:name => 'example.com')

--- a/spec/cli/ssh_cli_spec.rb
+++ b/spec/cli/ssh_cli_spec.rb
@@ -6,7 +6,7 @@ describe Tugboat::CLI do
   describe "ssh" do
     it "tries to fetch the droplet's IP from the API" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
@@ -18,11 +18,11 @@ describe Tugboat::CLI do
 
     it "wait's until droplet active if -w command is given and droplet already active" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => "", :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets/6918990?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplet'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
@@ -45,11 +45,11 @@ SShing with options: -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownH
 
     it "wait's until droplet active if -w command is given and droplet eventually active" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => "", :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets/6918990?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(
             {:status => 200, :body => fixture('show_droplet_inactive'), :headers => {}},
             {:status => 200, :body => fixture('show_droplet'), :headers => {}}
@@ -75,7 +75,7 @@ SShing with options: -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownH
 
     it "does not allow ssh into a droplet that is inactive" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").

--- a/spec/cli/start_cli_spec.rb
+++ b/spec/cli/start_cli_spec.rb
@@ -6,16 +6,16 @@ describe Tugboat::CLI do
   describe "start" do
     it "starts the droplet with a fuzzy name" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:post, "https://api.digitalocean.com/v2/droplets/3164444/actions").
          with(:body => "{\"type\":\"power_on\"}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('droplet_start_response'), :headers => {})
 
       @cli.start("example3.com")
@@ -28,15 +28,15 @@ Queuing start for 3164444 (example3.com)...Start complete!
 
     it "starts the droplet with an id" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets/3164494?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:headers => {'Content-Type' => 'application/json'}, :status => 200, :body => fixture("show_droplet_inactive"))
 
       stub_request(:post, "https://api.digitalocean.com/v2/droplets/3164494/actions").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:headers => {'Content-Type' => 'application/json'}, :status => 200, :body => fixture("show_droplet_inactive"))
 
 
@@ -52,16 +52,16 @@ Queuing start for 3164494 (example.com)...Start complete!
 
     it "starts the droplet with a name" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:post, "https://api.digitalocean.com/v2/droplets/3164444/actions").
          with(:body => "{\"type\":\"power_on\"}",
-              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('droplet_start_response'), :headers => {})
 
       @cli.options = @cli.options.merge(:name => 'example3.com')
@@ -75,11 +75,11 @@ Queuing start for 3164444 (example3.com)...Start complete!
 
     it "does not start a droplet that is inactive" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       @cli.options = @cli.options.merge(:name => 'example.com')

--- a/spec/cli/verify_cli_spec.rb
+++ b/spec/cli/verify_cli_spec.rb
@@ -6,7 +6,7 @@ describe Tugboat::CLI do
   describe "verify" do
     it "returns confirmation text when verify passes" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       @cli.verify
@@ -16,7 +16,7 @@ describe Tugboat::CLI do
 
     it "returns error when verify fails" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:headers => {'Content-Type' => 'text/html'}, :status => 401, :body => fixture('401'))
 
       expect { @cli.verify }.to raise_error(SystemExit)
@@ -26,7 +26,7 @@ describe Tugboat::CLI do
 
     it "returns error string when verify fails and a non-json reponse is given" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-        with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+        with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
         to_return(:headers => {'Content-Type' => 'text/html'}, :status => 500, :body => fixture('500','html'))
 
       expect { @cli.verify }.to raise_error(SystemExit)

--- a/spec/cli/wait_cli_spec.rb
+++ b/spec/cli/wait_cli_spec.rb
@@ -6,15 +6,15 @@ describe Tugboat::CLI do
   describe "wait" do
     it "waits for a droplet with a fuzzy name" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets/6918990?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplet'), :headers => {})
 
       @cli.options = @cli.options.merge(:state => "active")
@@ -28,15 +28,15 @@ eos
 
     it "loops whilst it waits for state" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets/6918990?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(
             {:status => 200, :body => fixture('show_droplet_inactive'), :headers => {}},
             {:status => 200, :body => fixture('show_droplet'), :headers => {}}
@@ -53,11 +53,11 @@ eos
 
     it "waits for a droplet with an id" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets/6918990?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplet'), :headers => {})
 
       @cli.options = @cli.options.merge(:id => '6918990', :state => "active")
@@ -71,15 +71,15 @@ Waiting for droplet to become active..done\e[0m (0s)
 
     it "waits for a droplet with a name" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplets'), :headers => {})
 
       stub_request(:get, "https://api.digitalocean.com/v2/droplets/6918990?per_page=200").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:status => 200, :body => fixture('show_droplet'), :headers => {})
 
       @cli.options = @cli.options.merge(:name => 'example.com', :state => "active")

--- a/spec/middleware/check_credentials_spec.rb
+++ b/spec/middleware/check_credentials_spec.rb
@@ -6,7 +6,7 @@ describe Tugboat::Middleware::CheckCredentials do
   describe ".call" do
     it "raises SystemExit with no configuration" do
       stub_request(:get, "https://api.digitalocean.com/v2/droplets?page=1&per_page=1").
-         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.9.2'}).
+         with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer foo', 'Content-Type'=>'application/json', 'User-Agent'=>'Faraday v0.11.0'}).
          to_return(:headers => {'Content-Type' => 'application/json'}, :status => 401, :body => fixture('401'))
 
       # Inject the client.

--- a/tugboat.gemspec
+++ b/tugboat.gemspec
@@ -18,9 +18,10 @@ Gem::Specification.new do |gem|
   gem.require_paths         = ['lib']
   gem.required_ruby_version = '>= 1.9.2'
 
-  gem.add_dependency 'thor', '~> 0.18.1'
-  gem.add_dependency 'barge', '~> 0.12.0'
-  gem.add_dependency 'middleware', '~> 0.1.0'
+  gem.add_dependency 'thor', '0.18.1'
+  gem.add_dependency 'barge', '0.12.0'
+  gem.add_dependency 'middleware', '0.1.0'
+  gem.add_dependency 'faraday', '0.11.0'
 
   gem.add_development_dependency 'rake', '< 11.0'
   gem.add_development_dependency 'rspec-core', '~> 2.14.0'
@@ -31,7 +32,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'simplecov-console', '0.2.0'
   gem.add_development_dependency 'coveralls', '~> 0.6.7'
   gem.add_development_dependency 'aruba', '0.7.4'
-  gem.add_development_dependency 'pry'
+  gem.add_development_dependency 'pry', '0.10.4'
   gem.add_development_dependency 'vcr', '2.9.3'
 
   gem.post_install_message = '***************************************'


### PR DESCRIPTION
* Faraday wasn't pinned, so updated, breaking all
specs
* This is way more of a bigger deal, as faraday is
a core dependency! 
* Pinned to 0.11.0 release
* Updated specs to refer to new faraday version
* Pinned other dev dependancy gems