### PR TITLE
Moves cucumber dependancy into gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in tugboat.gemspec
 gemspec
-
-group :development do
-  # Random order is not in the Aruba Cucumber yet...
-  gem 'cucumber', git: 'https://github.com/cucumber/cucumber-ruby.git', tag: 'v2.0.2'
-  gem 'cucumber-core', git: 'https://github.com/cucumber/cucumber-ruby-core.git', tag: 'v1.2.0'
-end

--- a/tugboat.gemspec
+++ b/tugboat.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'aruba', '0.7.4'
   gem.add_development_dependency 'pry', '0.10.4'
   gem.add_development_dependency 'vcr', '2.9.3'
+  gem.add_development_dependency 'cucumber', '2.0.2'
 
   gem.post_install_message = '***************************************'
   gem.post_install_message = '   .  o ..                            '


### PR DESCRIPTION
* The random order feature was not available in 
cucumber at the time
* This meant I had to refer to the github ref
* Now it's in core, we can move to `.gemspec`