### PR TITLE
Adds 'THOR_SHELL' env mock for 'DEBUG' spec

### DIFF
--- a/spec/cli/debug_cli_spec.rb
+++ b/spec/cli/debug_cli_spec.rb
@@ -9,6 +9,7 @@ describe Tugboat::CLI do
       allow(ENV).to receive(:[]).with('DEBUG').and_return(1)
       allow(ENV).to receive(:[]).with('http_proxy').and_return(nil)
       allow(ENV).to receive(:[]).with('DO_API_TOKEN').and_return(nil)
+      allow(ENV).to receive(:[]).with('THOR_SHELL').and_return(nil)
     end
 
     it "gives full faraday logs" do
@@ -35,6 +36,7 @@ describe Tugboat::CLI do
       allow(ENV).to receive(:[]).with('DEBUG').and_return(2)
       allow(ENV).to receive(:[]).with('http_proxy').and_return(nil)
       allow(ENV).to receive(:[]).with('DO_API_TOKEN').and_return(nil)
+      allow(ENV).to receive(:[]).with('THOR_SHELL').and_return(nil)
     end
 
     it "gives full faraday logs with redacted API keys" do


### PR DESCRIPTION
Otherwise we get the following:

```
Failure/Error: cli.droplets
       ENV received :[] with unexpected arguments
         expected: ("DO_API_TOKEN")
              got: ("THOR_SHELL")
```