### PR TITLE
Adds ability to disable colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,17 @@ Or just list images that you have created.
 
 ### Wait for Droplet State
 
+While the colorized output of tugboat droplets is nice when visually inspecting the output, it can cause problems when one wants to use the command in scripts (either logging information to a file, or using it to check the status of a droplet).
+
+You can disable it with the use of the Thor environmental variable:
+
+    $ THOR_SHELL=Basic bundle exec tugboat verify
+    Authentication with DigitalOcean was successful.
+
+All text will be output without colors.
+
+### Disabling color from output
+
 Sometimes you want to wait for a droplet to enter some state, for
 example "off".
 

--- a/lib/tugboat/middleware/base.rb
+++ b/lib/tugboat/middleware/base.rb
@@ -3,10 +3,18 @@ module Tugboat
     # A base middleware class to initalize.
     class Base
       # Some colors for making things pretty.
-      CLEAR      = "\e[0m".freeze
-      RED        = "\e[31m".freeze
-      GREEN      = "\e[32m".freeze
-      YELLOW     = "\e[33m".freeze
+
+      if ENV['THOR_SHELL'] == 'Basic'
+        CLEAR      = "\e[0m".freeze
+        RED        = "\e[0m".freeze
+        GREEN      = "\e[0m".freeze
+        YELLOW     = "\e[0m".freeze
+      else
+        CLEAR      = "\e[0m".freeze
+        RED        = "\e[31m".freeze
+        GREEN      = "\e[32m".freeze
+        YELLOW     = "\e[33m".freeze
+      end
 
       # We want access to all of the fun thor cli helper methods,
       # like say, yes?, ask, etc.

--- a/spec/cli/env_variable_spec.rb
+++ b/spec/cli/env_variable_spec.rb
@@ -36,4 +36,49 @@ describe Tugboat::CLI do
       expect(a_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=1')).to have_been_made
     end
   end
+
+  describe 'THOR_SHELL=Basic' do
+    it 'removes colour from the string if THOR_SHELL is set to basic' do
+      stub_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=1').
+        with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
+        to_return(status: 200, body: fixture('show_droplets'), headers: {})
+
+      allow(ENV).to receive(:[]).with('DEBUG').and_return(nil)
+      allow(ENV).to receive(:[]).with('http_proxy').and_return(nil)
+      allow(ENV).to receive(:[]).with('DO_API_TOKEN').and_return(nil)
+      allow(ENV).to receive(:[]).with('HOME').and_return('/tmp/fake_home')
+      allow(ENV).to receive(:[]).with('THOR_SHELL').and_return('Basic')
+
+      expected_string =   <<-eos
+Authentication with DigitalOcean was successful.
+      eos
+
+      not_expected_string =   <<-eos
+\e[32mAuthentication with DigitalOcean was successful.\e[0m
+      eos
+
+      expectation = expect { cli.verify }
+      expectation.to output(expected_string).to_stdout
+      expectation.to_not output(not_expected_string).to_stdout
+    end
+
+    it 'leaves colour from the string if THOR_SHELL is not set to basic' do
+      stub_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=1').
+        with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
+        to_return(status: 200, body: fixture('show_droplets'), headers: {})
+
+      allow(ENV).to receive(:[]).with('DEBUG').and_return(nil)
+      allow(ENV).to receive(:[]).with('http_proxy').and_return(nil)
+      allow(ENV).to receive(:[]).with('DO_API_TOKEN').and_return(nil)
+      allow(ENV).to receive(:[]).with('HOME').and_return('/tmp/fake_home')
+      allow(ENV).to receive(:[]).with('THOR_SHELL').and_return('Color')
+
+      expected_string =   <<-eos
+\e[32mAuthentication with DigitalOcean was successful.\e[0m
+      eos
+
+      expected_string = "Authentication with DigitalOcean was successful.\n"
+      expect { cli.verify }.to output(expected_string).to_stdout
+    end
+  end
 end


### PR DESCRIPTION
* You can disable colour output for Thor with the environmental variables with `THOR_SHELL=Basic`
* However, this only works for `say ‘hello’, :green`, it won’t apply for custom strings with colour constants in them
* So we add the environmental lookup to our colour code as well!
* Closes #93